### PR TITLE
Update PRD: notifikasi undangan rapat via Telegram

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -13,6 +13,7 @@ Aplikasi internal berbasis Spring Boot (MVC + Thymeleaf) yang memusatkan penjadw
 2. **Keberhasilan sync kalender ≥ 99%** dari seluruh rapat yang dijadwalkan berhasil terbuat sebagai event Google Calendar dengan invite terkirim ke seluruh peserta tanpa error.
 3. **Kelengkapan notulensi ≥ 95%** dari rapat yang sudah selesai memiliki link/notulensi tercatat dan dapat diakses oleh peserta terkait dalam 3 hari kerja setelah rapat selesai.
 4. **Adopsi 100%** — seluruh Ketua Divisi menjadwalkan rapat melalui aplikasi (bukan lagi manual/WA/kalender pribadi) dalam 1 bulan setelah rollout.
+5. **Notifikasi Telegram terkirim ≥ 95%** dari rapat yang memilih minimal satu grup Telegram tujuan berhasil mengirim pesan undangan ke seluruh grup terpilih tanpa error.
 
 ## 2. User Experience & Functionality
 
@@ -20,9 +21,9 @@ Aplikasi internal berbasis Spring Boot (MVC + Thymeleaf) yang memusatkan penjadw
 
 | Persona | Peran |
 |---|---|
-| **Admin** | Mengelola pengguna, divisi, dan penunjukan notulis lintas divisi. |
+| **Admin** | Mengelola pengguna, divisi, penunjukan notulis lintas divisi, dan data grup Telegram. |
 | **Direktur** | Pemangku masalah utama: butuh visibilitas penuh atas semua rapat lintas divisi dan akses cepat ke notulensi. |
-| **Ketua Divisi** | Membuat & mengelola jadwal rapat divisinya, menunjuk notulis, mengisi notulensi. |
+| **Ketua Divisi** | Membuat & mengelola jadwal rapat divisinya, memilih grup Telegram tujuan undangan, menunjuk notulis, mengisi notulensi. |
 | **Karyawan** | Peserta rapat; melihat jadwal rapat divisinya dan notulensi rapat yang bisa diaksesnya; bisa ditunjuk sebagai notulis untuk rapat tertentu. |
 
 ### User Stories & Acceptance Criteria
@@ -59,6 +60,25 @@ Sebagai Ketua Divisi atau Admin, saya ingin menunjuk karyawan tertentu sebagai n
 - AC: Ketua Divisi tetap memiliki hak menulis notulensi untuk semua rapat divisinya sendiri, tanpa perlu ditunjuk.
 - AC: Karyawan yang bukan notulis dan bukan Ketua Divisi/Admin hanya bisa membaca, tidak bisa mengedit notulensi.
 
+**US-6 — Memilih grup Telegram tujuan saat membuat rapat**
+Sebagai Ketua Divisi, saya ingin memilih satu atau lebih grup Telegram saat membuat rapat, supaya undangan rapat otomatis terkirim ke grup Telegram yang relevan tanpa perlu forward manual.
+- AC: Form pembuatan rapat menampilkan daftar grup Telegram aktif untuk dipilih (bisa lebih dari satu).
+- AC: Grup Telegram favorit milik divisi Ketua Divisi tersebut otomatis sudah tercentang saat form dibuka, tapi tetap bisa ditambah/dikurangi sebelum submit.
+- AC: Setelah rapat disimpan, sistem otomatis mengirim pesan undangan (judul, waktu, link materi) ke setiap grup Telegram yang dipilih.
+- AC: Kegagalan pengiriman ke satu/lebih grup Telegram tidak menggagalkan pembuatan rapat itu sendiri; status kirim per grup dicatat (sukses/gagal), mengikuti pola status sync Google Calendar yang sudah ada (lihat US-2).
+
+**US-7 — Admin mengelola data grup Telegram**
+Sebagai Admin, saya ingin menambah, mengubah, dan menghapus data grup Telegram, supaya daftar grup yang tersedia untuk dipilih saat membuat rapat selalu akurat.
+- AC: Admin bisa menambah grup Telegram baru dengan nama dan Chat ID.
+- AC: Admin bisa mengubah nama, Chat ID, atau status aktif grup Telegram yang sudah ada.
+- AC: Admin bisa menonaktifkan/menghapus grup Telegram dari daftar pilihan; rapat lama yang sudah terlanjur mengirim ke grup tersebut tetap menyimpan riwayatnya.
+
+**US-8 — Grup Telegram favorit per divisi**
+Sebagai Admin atau Ketua Divisi, saya ingin menandai satu atau lebih grup Telegram sebagai favorit untuk suatu divisi, supaya grup tersebut otomatis terpilih setiap kali ada rapat baru di divisi itu.
+- AC: Satu divisi bisa punya lebih dari satu grup Telegram favorit.
+- AC: Satu grup Telegram yang sama boleh menjadi favorit lebih dari satu divisi.
+- AC: Perubahan daftar favorit divisi hanya memengaruhi default pilihan di form rapat baru berikutnya, tidak mengubah rapat yang sudah dibuat sebelumnya.
+
 ### Non-Goals
 
 - Tidak membangun aplikasi mobile native (web responsive melalui Thymeleaf sudah cukup untuk rilis ini).
@@ -67,6 +87,9 @@ Sebagai Ketua Divisi atau Admin, saya ingin menunjuk karyawan tertentu sebagai n
 - Tidak membangun integrasi video conference (Zoom/Google Meet) — cukup link materi/notulensi berupa Google Doc.
 - Tidak menyalin/menduplikasi konten Google Doc ke database — aplikasi hanya menyimpan link + ringkasan notulensi berupa teks, bukan mem-*mirror* dokumen.
 - Tidak membangun dashboard analitik/rekap kehadiran rapat pada rilis ini.
+- Notifikasi Telegram bersifat tambahan/paralel terhadap sync Google Calendar — bukan pengganti, dan tidak menggantikan undangan Calendar yang sudah ada.
+- Tidak ada percakapan dua arah lewat bot Telegram (bot hanya mengirim pesan satu arah, tidak membaca/merespons pesan dari grup).
+- Tidak mendukung platform chat lain (WhatsApp, Slack, dll.) di luar Telegram pada rilis ini.
 
 ## 3. Technical Specifications
 
@@ -75,14 +98,17 @@ Sebagai Ketua Divisi atau Admin, saya ingin menunjuk karyawan tertentu sebagai n
 ### Architecture Overview
 
 - **Spring Boot MVC + Thymeleaf**: aplikasi web server-rendered, satu modular monolith.
-- **Spring Modulith**: setiap domain (mis. `division`, `meeting`, `user`, `notulensi`) menjadi modul terpisah di bawah `com.example.vibe1.*`, dengan batas modul yang diverifikasi Modulith.
-- **Alur utama pembuatan rapat**: Ketua Divisi mengisi form rapat → aplikasi menyimpan entitas `Meeting` beserta daftar peserta (termasuk Direktur yang ditambahkan otomatis) → aplikasi memanggil Google Calendar API untuk membuat event dengan attendee list → status sync disimpan di `Meeting` (sukses/gagal + timestamp).
+- **Spring Modulith**: setiap domain (mis. `division`, `meeting`, `user`, `notulensi`, `telegram`) menjadi modul terpisah di bawah `com.example.vibe1.*`, dengan batas modul yang diverifikasi Modulith.
+- **Alur utama pembuatan rapat**: Ketua Divisi mengisi form rapat (termasuk pilihan grup Telegram tujuan, pre-filled dari favorit divisi) → aplikasi menyimpan entitas `Meeting` beserta daftar peserta (termasuk Direktur yang ditambahkan otomatis) dan daftar grup Telegram terpilih → aplikasi memanggil Google Calendar API untuk membuat event dengan attendee list → status sync disimpan di `Meeting` (sukses/gagal + timestamp).
+- **Alur notifikasi Telegram**: berjalan paralel dengan alur sync Google Calendar, dipicu oleh event yang sama saat rapat tersimpan → untuk setiap grup Telegram yang dipilih, aplikasi mengirim pesan undangan lewat Telegram Bot API → status kirim per grup dicatat (sukses/gagal); kegagalan tidak membatalkan pembuatan rapat maupun sync Calendar-nya.
 - **Alur notulensi**: Ketua Divisi/Admin menunjuk notulis untuk rapat tertentu → hak edit tersimpan sebagai relasi (mis. tabel penunjukan notulis per-rapat) → notulis/Ketua Divisi mengisi link Google Doc + ringkasan notulensi pada detail rapat → peserta rapat (sesuai aturan visibilitas divisi) dapat membaca hasilnya.
+- **Data grup Telegram**: entitas grup Telegram (nama, Chat ID, status aktif) dikelola Admin; relasi favorit menghubungkan satu divisi ke banyak grup (many-to-many) sebagai default pilihan; relasi terpisah mencatat grup mana saja yang benar-benar dipilih untuk satu rapat tertentu (independen dari daftar favorit, karena favorit bisa berubah setelah rapat dibuat).
 
 ### Integration Points
 
 - **Google OAuth2** (Spring Security OAuth2 Client) untuk login akun Google dan memperoleh consent scope Google Calendar.
 - **Google Calendar API** untuk membuat/memperbarui/membatalkan event rapat beserta attendee.
+- **Telegram Bot API** untuk mengirim pesan undangan rapat ke grup Telegram yang dipilih. Bot harus sudah ditambahkan sebagai member/admin di grup tujuan sebelum bisa mengirim pesan — prasyarat operasional manual, bukan sesuatu yang bisa diotomatisasi dari sisi aplikasi.
 - **MariaDB** melalui **Spring Data JPA**, skema dikelola dengan **Liquibase** (changelog per fitur, tidak ada perubahan skema manual di luar migration).
 
 ### Security & Privacy
@@ -90,14 +116,14 @@ Sebagai Ketua Divisi atau Admin, saya ingin menunjuk karyawan tertentu sebagai n
 - **RBAC** berbasis peran (Admin, Direktur, Ketua Divisi, Karyawan) untuk kontrol akses fitur secara umum (siapa bisa membuat rapat, siapa bisa melihat divisi mana).
 - **Izin granular per-rapat** untuk penunjukan notulis — dimodelkan sebagai relasi terpisah dari role, agar tidak mencemari hierarki RBAC dengan role sementara/per-kasus.
 - **Token OAuth Google** (access/refresh token) disimpan terenkripsi di database, tidak pernah di-log atau ditampilkan di UI.
-- Kredensial database & OAuth client disimpan sebagai environment variable (`.env`, tidak masuk version control), bukan hardcoded di source atau file scope.
+- Kredensial database, OAuth client, dan token bot Telegram disimpan sebagai environment variable (`.env`, tidak masuk version control), bukan hardcoded di source atau file scope.
 - Data yang disimpan aplikasi terbatas pada metadata rapat (judul, waktu, peserta, link, ringkasan notulensi) — dokumen Google Doc sendiri tetap berada di Google Workspace perusahaan, tunduk pada kontrol akses Google Workspace yang sudah ada.
 
 ## 4. Risks & Roadmap
 
 ### Rollout
 
-Rilis dilakukan **sekaligus dengan scope penuh** (US-1 s/d US-5 di atas) — tidak dipecah menjadi MVP/v1.1 pada PRD ini. Item di bagian Non-Goals (mobile app, multi-tenant, recurring meeting, integrasi video conference, dashboard analitik) menjadi kandidat backlog untuk evaluasi kebutuhan berikutnya, bukan komitmen rilis ini.
+Rilis awal dilakukan **sekaligus dengan scope penuh** (US-1 s/d US-5) — tidak dipecah menjadi MVP/v1.1. Notifikasi Telegram (US-6 s/d US-8) adalah **penambahan requirement setelah rilis awal**, mengikuti pola rilis yang sama (langsung scope penuh, bukan bertahap). Item di bagian Non-Goals (mobile app, multi-tenant, recurring meeting, integrasi video conference, dashboard analitik, platform chat selain Telegram) menjadi kandidat backlog untuk evaluasi kebutuhan berikutnya, bukan komitmen rilis ini.
 
 ### Technical Risks
 
@@ -106,3 +132,6 @@ Rilis dilakukan **sekaligus dengan scope penuh** (US-1 s/d US-5 di atas) — tid
 - **Reliabilitas notifikasi tetap bergantung pada sistem Google Calendar** di sisi klien (pengaturan notifikasi akun Google masing-masing pengguna) — aplikasi hanya memastikan event & invite terkirim dengan benar, bukan menjamin pengaturan notifikasi pribadi pengguna.
 - **Migrasi skema via Liquibase**: perubahan skema untuk entitas baru (rapat, penunjukan notulis, dsb.) harus terkontrol lewat changelog agar tidak konflik antar developer.
 - **Kesalahan pemodelan RBAC vs izin per-rapat**: risiko implementasi menyederhanakan penunjukan notulis menjadi role global, yang akan sulit di-scale dan tidak sesuai kebutuhan (lihat US-5).
+- **Prasyarat manual bot Telegram**: bot harus sudah ditambahkan sebagai member/admin di setiap grup tujuan, dan Chat ID grup harus diperoleh & dimasukkan Admin secara manual — tidak ada mekanisme discovery/consent otomatis seperti OAuth Google Calendar, sehingga rawan human error saat setup awal.
+- **Rate limit Telegram Bot API**: pengiriman ke banyak grup sekaligus (mis. rapat dengan banyak grup terpilih, atau banyak rapat dibuat bersamaan) berisiko tertunda/gagal jika kena limit.
+- **Kegagalan kirim Telegram tidak boleh menggagalkan pembuatan rapat**: harus mengikuti pola yang sama seperti status `FAILED` pada sync Google Calendar (lihat US-2) — gagal kirim ke satu grup tidak boleh membatalkan rapat atau sync Calendar-nya.


### PR DESCRIPTION
## Summary

Memodifikasi `PRD.md` sesuai rencana di issue #5 -- dokumen saja, tidak ada perubahan kode. Menambahkan:

- US-6, US-7, US-8 (pilih grup Telegram saat buat rapat + auto-fill favorit divisi, Admin CRUD grup Telegram, grup favorit per divisi)
- Success Criteria KPI baru untuk keberhasilan kirim Telegram
- Non-Goals: notifikasi Telegram paralel/tambahan (bukan pengganti Calendar), satu arah, tidak ada platform chat lain
- Architecture Overview & Integration Points: alur notifikasi Telegram mengikuti pola sync Google Calendar yang sudah ada (gagal kirim tidak membatalkan rapat)
- Risks & Roadmap: prasyarat manual bot harus di-invite ke grup + Chat ID diinput manual, rate limit API

Closes #5

## Test plan

Dokumentasi saja -- tidak ada test kode. Implementasi sebenarnya (entity, integrasi Telegram Bot API, UI) menyusul di issue terpisah.

🤖 Generated with [Claude Code](https://claude.com/claude-code)