### PR TITLE
[Telegram] Admin CRUD grup Telegram, favorit per divisi, & pengaturan token bot

### DIFF
--- a/src/main/java/com/example/vibe1/telegram/DivisionTelegramGroupService.java
+++ b/src/main/java/com/example/vibe1/telegram/DivisionTelegramGroupService.java
@@ -1,0 +1,45 @@
+package com.example.vibe1.telegram;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.vibe1.division.Division;
+import com.example.vibe1.division.DivisionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/** Which Telegram groups are a division's favorites -- default selection on the meeting-creation form (see issue #10). */
+@Service
+@RequiredArgsConstructor
+public class DivisionTelegramGroupService {
+
+    private final DivisionTelegramGroupRepository divisionTelegramGroupRepository;
+    private final TelegramGroupRepository telegramGroupRepository;
+    private final DivisionRepository divisionRepository;
+
+    @Transactional(readOnly = true)
+    public Set<Long> findFavoriteGroupIds(Long divisionId) {
+        return divisionTelegramGroupRepository.findByDivisionId(divisionId).stream()
+                .map(favorite -> favorite.getTelegramGroup().getId())
+                .collect(Collectors.toSet());
+    }
+
+    /** Replaces the whole favorite set for a division -- simplest correct approach for a small admin-managed list. */
+    @Transactional
+    public void replaceFavorites(Long divisionId, List<Long> telegramGroupIds) {
+        Division division = divisionRepository.findById(divisionId)
+                .orElseThrow(() -> new IllegalArgumentException("Divisi tidak ditemukan"));
+
+        divisionTelegramGroupRepository.deleteAll(divisionTelegramGroupRepository.findByDivisionId(divisionId));
+
+        for (Long groupId : telegramGroupIds) {
+            TelegramGroup group = telegramGroupRepository.findById(groupId)
+                    .orElseThrow(() -> new IllegalArgumentException("Grup Telegram tidak ditemukan: " + groupId));
+            divisionTelegramGroupRepository.save(new DivisionTelegramGroup(division, group));
+        }
+    }
+}

--- a/src/main/java/com/example/vibe1/telegram/TelegramGroupService.java
+++ b/src/main/java/com/example/vibe1/telegram/TelegramGroupService.java
@@ -1,0 +1,52 @@
+package com.example.vibe1.telegram;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TelegramGroupService {
+
+    private final TelegramGroupRepository telegramGroupRepository;
+
+    public List<TelegramGroup> findAll() {
+        return telegramGroupRepository.findAll();
+    }
+
+    public List<TelegramGroup> findActive() {
+        return telegramGroupRepository.findByEnabledTrue();
+    }
+
+    public TelegramGroup findById(Long id) {
+        return telegramGroupRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Grup Telegram tidak ditemukan"));
+    }
+
+    @Transactional
+    public TelegramGroup create(String name, String chatId) {
+        assertChatIdAvailable(chatId, null);
+        return telegramGroupRepository.save(new TelegramGroup(name, chatId));
+    }
+
+    @Transactional
+    public TelegramGroup update(Long id, String name, String chatId, boolean enabled) {
+        assertChatIdAvailable(chatId, id);
+        TelegramGroup group = findById(id);
+        group.setName(name);
+        group.setChatId(chatId);
+        group.setEnabled(enabled);
+        return telegramGroupRepository.save(group);
+    }
+
+    private void assertChatIdAvailable(String chatId, Long excludingId) {
+        telegramGroupRepository.findByChatId(chatId)
+                .filter(existing -> !existing.getId().equals(excludingId))
+                .ifPresent(existing -> {
+                    throw new IllegalArgumentException("Chat ID sudah dipakai grup lain");
+                });
+    }
+}

--- a/src/main/java/com/example/vibe1/telegram/web/DivisionTelegramGroupAdminController.java
+++ b/src/main/java/com/example/vibe1/telegram/web/DivisionTelegramGroupAdminController.java
@@ -1,0 +1,53 @@
+package com.example.vibe1.telegram.web;
+
+import java.util.List;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.example.vibe1.division.Division;
+import com.example.vibe1.division.DivisionRepository;
+import com.example.vibe1.telegram.DivisionTelegramGroupService;
+import com.example.vibe1.telegram.TelegramGroupService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Lives in the telegram module (not division.web) even though its route is
+ * nested under /admin/divisions/** -- division must stay a dependency-free
+ * leaf module (telegram -> division already exists via DivisionTelegramGroup,
+ * so division -> telegram would close a 2-module cycle).
+ */
+@Controller
+@RequestMapping("/admin/divisions/{divisionId}/telegram-groups")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+public class DivisionTelegramGroupAdminController {
+
+    private final DivisionRepository divisionRepository;
+    private final TelegramGroupService telegramGroupService;
+    private final DivisionTelegramGroupService divisionTelegramGroupService;
+
+    @GetMapping
+    public String edit(@PathVariable Long divisionId, Model model) {
+        Division division = divisionRepository.findById(divisionId)
+                .orElseThrow(() -> new IllegalArgumentException("Divisi tidak ditemukan"));
+        model.addAttribute("division", division);
+        model.addAttribute("groups", telegramGroupService.findActive());
+        model.addAttribute("favoriteIds", divisionTelegramGroupService.findFavoriteGroupIds(divisionId));
+        return "admin/division-telegram-groups";
+    }
+
+    @PostMapping
+    public String update(@PathVariable Long divisionId,
+                          @RequestParam(name = "telegramGroupIds", required = false) List<Long> telegramGroupIds) {
+        divisionTelegramGroupService.replaceFavorites(divisionId, telegramGroupIds == null ? List.of() : telegramGroupIds);
+        return "redirect:/admin/divisions";
+    }
+}

--- a/src/main/java/com/example/vibe1/telegram/web/TelegramGroupAdminController.java
+++ b/src/main/java/com/example/vibe1/telegram/web/TelegramGroupAdminController.java
@@ -1,0 +1,73 @@
+package com.example.vibe1.telegram.web;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.example.vibe1.telegram.TelegramGroup;
+import com.example.vibe1.telegram.TelegramGroupService;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequestMapping("/admin/telegram-groups")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+public class TelegramGroupAdminController {
+
+    private final TelegramGroupService telegramGroupService;
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("groups", telegramGroupService.findAll());
+        return "admin/telegram-group-list";
+    }
+
+    @GetMapping("/new")
+    public String newForm(Model model) {
+        model.addAttribute("form", new TelegramGroupForm());
+        return "admin/telegram-group-form";
+    }
+
+    @PostMapping
+    public String create(@ModelAttribute("form") TelegramGroupForm form, BindingResult bindingResult) {
+        try {
+            telegramGroupService.create(form.getName(), form.getChatId());
+        } catch (IllegalArgumentException ex) {
+            bindingResult.reject("error", ex.getMessage());
+        }
+        return bindingResult.hasErrors() ? "admin/telegram-group-form" : "redirect:/admin/telegram-groups";
+    }
+
+    @GetMapping("/{id}/edit")
+    public String editForm(@PathVariable Long id, Model model) {
+        TelegramGroup group = telegramGroupService.findById(id);
+        TelegramGroupForm form = new TelegramGroupForm();
+        form.setName(group.getName());
+        form.setChatId(group.getChatId());
+        form.setEnabled(group.isEnabled());
+        model.addAttribute("form", form);
+        model.addAttribute("groupId", id);
+        return "admin/telegram-group-form";
+    }
+
+    @PostMapping("/{id}")
+    public String update(@PathVariable Long id, @ModelAttribute("form") TelegramGroupForm form, BindingResult bindingResult, Model model) {
+        try {
+            telegramGroupService.update(id, form.getName(), form.getChatId(), form.isEnabled());
+        } catch (IllegalArgumentException ex) {
+            bindingResult.reject("error", ex.getMessage());
+        }
+        if (bindingResult.hasErrors()) {
+            model.addAttribute("groupId", id);
+            return "admin/telegram-group-form";
+        }
+        return "redirect:/admin/telegram-groups";
+    }
+}

--- a/src/main/java/com/example/vibe1/telegram/web/TelegramGroupForm.java
+++ b/src/main/java/com/example/vibe1/telegram/web/TelegramGroupForm.java
@@ -1,0 +1,13 @@
+package com.example.vibe1.telegram.web;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TelegramGroupForm {
+
+    private String name;
+    private String chatId;
+    private boolean enabled = true;
+}

--- a/src/main/java/com/example/vibe1/telegram/web/TelegramSettingsController.java
+++ b/src/main/java/com/example/vibe1/telegram/web/TelegramSettingsController.java
@@ -1,0 +1,38 @@
+package com.example.vibe1.telegram.web;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.example.vibe1.telegram.TelegramBotConfigService;
+
+import lombok.RequiredArgsConstructor;
+
+/** The token is never redisplayed once saved -- only whether one is currently set. */
+@Controller
+@RequestMapping("/admin/telegram/settings")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+public class TelegramSettingsController {
+
+    private final TelegramBotConfigService telegramBotConfigService;
+
+    @GetMapping
+    public String edit(Model model) {
+        model.addAttribute("tokenConfigured", telegramBotConfigService.currentToken().isPresent());
+        model.addAttribute("form", new TelegramSettingsForm());
+        return "admin/telegram-settings";
+    }
+
+    @PostMapping
+    public String update(@ModelAttribute("form") TelegramSettingsForm form) {
+        if (form.getToken() != null && !form.getToken().isBlank()) {
+            telegramBotConfigService.save(form.getToken());
+        }
+        return "redirect:/admin/telegram/settings";
+    }
+}

--- a/src/main/java/com/example/vibe1/telegram/web/TelegramSettingsForm.java
+++ b/src/main/java/com/example/vibe1/telegram/web/TelegramSettingsForm.java
@@ -1,0 +1,12 @@
+package com.example.vibe1.telegram.web;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TelegramSettingsForm {
+
+    /** Blank means "keep the existing token unchanged" -- same convention as UserForm.password. */
+    private String token;
+}

--- a/src/main/resources/templates/admin/division-list.html
+++ b/src/main/resources/templates/admin/division-list.html
@@ -22,6 +22,8 @@
             <td th:text="${division.ketuaDivisiUserId} ?: '-'"></td>
             <td>
                 <a th:href="@{/admin/divisions/{id}/edit(id=${division.id})}">Edit</a>
+                &middot;
+                <a th:href="@{/admin/divisions/{id}/telegram-groups(id=${division.id})}">Grup Telegram</a>
             </td>
         </tr>
         </tbody>

--- a/src/main/resources/templates/admin/division-telegram-groups.html
+++ b/src/main/resources/templates/admin/division-telegram-groups.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/layout :: head('Grup Telegram Favorit')}"></head>
+<body>
+<nav th:replace="~{fragments/layout :: nav}"></nav>
+<main class="container" style="max-width: 500px;">
+    <h1 class="h4 mb-3">Grup Telegram Favorit &mdash; <span th:text="${division.name}"></span></h1>
+    <p class="text-muted small">Grup yang dicentang otomatis terpilih saat Ketua Divisi membuat rapat baru di divisi ini.</p>
+
+    <form method="post" th:action="@{/admin/divisions/{id}/telegram-groups(id=${division.id})}">
+        <div class="form-check" th:each="group : ${groups}">
+            <input class="form-check-input" type="checkbox" name="telegramGroupIds"
+                   th:id="${'group-' + group.id}" th:value="${group.id}"
+                   th:checked="${favoriteIds.contains(group.id)}"/>
+            <label class="form-check-label" th:for="${'group-' + group.id}" th:text="${group.name}"></label>
+        </div>
+        <div class="form-text mb-3" th:if="${#lists.isEmpty(groups)}">Belum ada grup Telegram aktif.</div>
+
+        <button class="btn btn-primary" type="submit">Simpan</button>
+        <a class="btn btn-link" th:href="@{/admin/divisions}">Batal</a>
+    </form>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/telegram-group-form.html
+++ b/src/main/resources/templates/admin/telegram-group-form.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/layout :: head('Form Grup Telegram')}"></head>
+<body>
+<nav th:replace="~{fragments/layout :: nav}"></nav>
+<main class="container" style="max-width: 500px;">
+    <h1 class="h4 mb-3">Form Grup Telegram</h1>
+    <form method="post" th:object="${form}"
+          th:action="${groupId} != null ? @{/admin/telegram-groups/{id}(id=${groupId})} : @{/admin/telegram-groups}">
+
+        <div class="alert alert-danger" th:if="${#fields.hasErrors('global')}" th:errors="*{global}"></div>
+
+        <div class="mb-3">
+            <label class="form-label" for="name">Nama Grup</label>
+            <input class="form-control" id="name" th:field="*{name}" required="required"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="chatId">Chat ID</label>
+            <input class="form-control" id="chatId" th:field="*{chatId}" required="required"/>
+            <div class="form-text">Didapat setelah bot ditambahkan ke grup Telegram tujuan.</div>
+        </div>
+        <div class="mb-3 form-check">
+            <input class="form-check-input" id="enabled" type="checkbox" th:field="*{enabled}"/>
+            <label class="form-check-label" for="enabled">Aktif</label>
+        </div>
+
+        <button class="btn btn-primary" type="submit">Simpan</button>
+        <a class="btn btn-link" th:href="@{/admin/telegram-groups}">Batal</a>
+    </form>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/telegram-group-list.html
+++ b/src/main/resources/templates/admin/telegram-group-list.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/layout :: head('Grup Telegram')}"></head>
+<body>
+<nav th:replace="~{fragments/layout :: nav}"></nav>
+<main class="container">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h4 mb-0">Grup Telegram</h1>
+        <div>
+            <a class="btn btn-outline-secondary" th:href="@{/admin/telegram/settings}">Pengaturan Token Bot</a>
+            <a class="btn btn-primary" th:href="@{/admin/telegram-groups/new}">Tambah Grup</a>
+        </div>
+    </div>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>Nama</th>
+            <th>Chat ID</th>
+            <th>Aktif</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="group : ${groups}">
+            <td th:text="${group.name}"></td>
+            <td th:text="${group.chatId}"></td>
+            <td th:text="${group.enabled} ? 'Ya' : 'Tidak'"></td>
+            <td>
+                <a th:href="@{/admin/telegram-groups/{id}/edit(id=${group.id})}">Edit</a>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+    <p class="text-muted small" th:if="${#lists.isEmpty(groups)}">Belum ada grup Telegram.</p>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/telegram-settings.html
+++ b/src/main/resources/templates/admin/telegram-settings.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/layout :: head('Pengaturan Telegram')}"></head>
+<body>
+<nav th:replace="~{fragments/layout :: nav}"></nav>
+<main class="container" style="max-width: 500px;">
+    <h1 class="h4 mb-3">Pengaturan Token Bot Telegram</h1>
+
+    <p>
+        Status token:
+        <span class="badge bg-success" th:if="${tokenConfigured}">Sudah diset</span>
+        <span class="badge bg-secondary" th:unless="${tokenConfigured}">Belum diset</span>
+    </p>
+
+    <form method="post" th:object="${form}" th:action="@{/admin/telegram/settings}">
+        <div class="mb-3">
+            <label class="form-label" for="token">Token Bot</label>
+            <input class="form-control" id="token" type="password" th:field="*{token}" autocomplete="off"/>
+            <div class="form-text">Kosongkan jika tidak ingin mengubah token yang sudah tersimpan. Token tidak pernah ditampilkan ulang setelah disimpan.</div>
+        </div>
+        <button class="btn btn-primary" type="submit">Simpan</button>
+    </form>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -16,6 +16,7 @@
             <a class="nav-link text-white" href="/meetings/new" sec:authorize="hasRole('KETUA_DIVISI')">Buat Rapat</a>
             <a class="nav-link text-white" href="/admin/divisions" sec:authorize="hasRole('ADMIN')">Divisi</a>
             <a class="nav-link text-white" href="/admin/users" sec:authorize="hasRole('ADMIN')">Pengguna</a>
+            <a class="nav-link text-white" href="/admin/telegram-groups" sec:authorize="hasRole('ADMIN')">Grup Telegram</a>
         </div>
         <form class="d-flex" method="post" th:action="@{/logout}">
             <button class="btn btn-outline-light btn-sm" type="submit">Logout</button>

--- a/src/test/java/com/example/vibe1/telegram/TelegramGroupServiceTest.java
+++ b/src/test/java/com/example/vibe1/telegram/TelegramGroupServiceTest.java
@@ -1,0 +1,56 @@
+package com.example.vibe1.telegram;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TelegramGroupServiceTest {
+
+    @Mock
+    TelegramGroupRepository telegramGroupRepository;
+
+    TelegramGroupService service;
+
+    @Test
+    void rejectsDuplicateChatIdOnCreate() {
+        service = new TelegramGroupService(telegramGroupRepository);
+        TelegramGroup existing = new TelegramGroup("Divisi Lain", "-1001111111111");
+        existing.setId(1L);
+        when(telegramGroupRepository.findByChatId("-1001111111111")).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.create("Grup Baru", "-1001111111111"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void allowsCreatingWithUnusedChatId() {
+        service = new TelegramGroupService(telegramGroupRepository);
+        lenient().when(telegramGroupRepository.findByChatId(any())).thenReturn(Optional.empty());
+        when(telegramGroupRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThatCode(() -> service.create("Grup Baru", "-1002222222222")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void updateAllowsKeepingItsOwnChatId() {
+        service = new TelegramGroupService(telegramGroupRepository);
+        TelegramGroup group = new TelegramGroup("Grup A", "-1003333333333");
+        group.setId(5L);
+        when(telegramGroupRepository.findByChatId("-1003333333333")).thenReturn(Optional.of(group));
+        when(telegramGroupRepository.findById(5L)).thenReturn(Optional.of(group));
+        when(telegramGroupRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThatCode(() -> service.update(5L, "Grup A (renamed)", "-1003333333333", true))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/example/vibe1/telegram/web/DivisionTelegramGroupAdminControllerTest.java
+++ b/src/test/java/com/example/vibe1/telegram/web/DivisionTelegramGroupAdminControllerTest.java
@@ -1,0 +1,41 @@
+package com.example.vibe1.telegram.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.vibe1.division.DivisionRepository;
+import com.example.vibe1.security.GoogleOidcUserService;
+import com.example.vibe1.security.SecurityConfig;
+import com.example.vibe1.telegram.DivisionTelegramGroupService;
+import com.example.vibe1.telegram.TelegramGroupService;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DivisionTelegramGroupAdminController.class)
+@Import(SecurityConfig.class)
+class DivisionTelegramGroupAdminControllerTest {
+
+    @MockitoBean
+    DivisionRepository divisionRepository;
+    @MockitoBean
+    TelegramGroupService telegramGroupService;
+    @MockitoBean
+    DivisionTelegramGroupService divisionTelegramGroupService;
+    @MockitoBean
+    GoogleOidcUserService googleOidcUserService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void nonAdminGets403() throws Exception {
+        mockMvc.perform(get("/admin/divisions/1/telegram-groups").with(user("karyawan@company.local").roles("KARYAWAN")))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/example/vibe1/telegram/web/TelegramGroupAdminControllerTest.java
+++ b/src/test/java/com/example/vibe1/telegram/web/TelegramGroupAdminControllerTest.java
@@ -1,0 +1,46 @@
+package com.example.vibe1.telegram.web;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.vibe1.security.GoogleOidcUserService;
+import com.example.vibe1.security.SecurityConfig;
+import com.example.vibe1.telegram.TelegramGroupService;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TelegramGroupAdminController.class)
+@Import(SecurityConfig.class)
+class TelegramGroupAdminControllerTest {
+
+    @MockitoBean
+    TelegramGroupService telegramGroupService;
+    @MockitoBean
+    GoogleOidcUserService googleOidcUserService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void nonAdminGets403() throws Exception {
+        mockMvc.perform(get("/admin/telegram-groups").with(user("karyawan@company.local").roles("KARYAWAN")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void adminCanAccessList() throws Exception {
+        when(telegramGroupService.findAll()).thenReturn(List.of());
+
+        mockMvc.perform(get("/admin/telegram-groups").with(user("admin@company.local").roles("ADMIN")))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/example/vibe1/telegram/web/TelegramSettingsControllerTest.java
+++ b/src/test/java/com/example/vibe1/telegram/web/TelegramSettingsControllerTest.java
@@ -1,0 +1,50 @@
+package com.example.vibe1.telegram.web;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.vibe1.security.GoogleOidcUserService;
+import com.example.vibe1.security.SecurityConfig;
+import com.example.vibe1.telegram.TelegramBotConfigService;
+
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** The saved token must never come back out through this page's HTML. */
+@WebMvcTest(TelegramSettingsController.class)
+@Import(SecurityConfig.class)
+class TelegramSettingsControllerTest {
+
+    @MockitoBean
+    TelegramBotConfigService telegramBotConfigService;
+    @MockitoBean
+    GoogleOidcUserService googleOidcUserService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void nonAdminGets403() throws Exception {
+        mockMvc.perform(get("/admin/telegram/settings").with(user("karyawan@company.local").roles("KARYAWAN")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void tokenValueNeverAppearsInResponseBody() throws Exception {
+        when(telegramBotConfigService.currentToken()).thenReturn(Optional.of("123456:super-secret-value"));
+
+        mockMvc.perform(get("/admin/telegram/settings").with(user("admin@company.local").roles("ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(content().string(not(org.hamcrest.Matchers.containsString("super-secret-value"))));
+    }
+}


### PR DESCRIPTION
## Summary

Implementasi issue #9:

- `/admin/telegram-groups` -- CRUD grup Telegram (nonaktifkan, bukan hard-delete; Chat ID tidak boleh duplikat).
- `/admin/divisions/{id}/telegram-groups` -- kelola grup favorit per divisi (checklist, replace-whole-set). Controller ditaruh di modul `telegram` (bukan `division.web`) supaya `division` tetap leaf module -- lihat komentar di kode & commit message.
- `/admin/telegram/settings` -- form isi/ganti token bot Telegram (dari issue #8's `TelegramBotConfigService`). Blank = tidak berubah; token tersimpan tidak pernah ditampilkan ulang.
- Semua endpoint baru: `@PreAuthorize("hasRole('ADMIN')")`.

## Test plan
- [x] `./gradlew build` hijau, `ModularityTests` tetap hijau (edge `telegram -> division` sudah ada sejak issue #7, tidak ada cycle baru).
- [x] `TelegramGroupServiceTest`: Chat ID duplikat ditolak, Chat ID sendiri saat update tetap boleh.
- [x] `TelegramGroupAdminControllerTest`, `DivisionTelegramGroupAdminControllerTest`, `TelegramSettingsControllerTest`: non-Admin ditolak 403.
- [x] `TelegramSettingsControllerTest`: nilai token yang sudah tersimpan dipastikan **tidak pernah** muncul di body response halaman pengaturan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)