### PR TITLE
Wire Telegram group selection and auto-send into meeting creation

### DIFF
--- a/src/main/java/com/example/vibe1/meeting/CreateMeetingCommand.java
+++ b/src/main/java/com/example/vibe1/meeting/CreateMeetingCommand.java
@@ -11,5 +11,6 @@ public record CreateMeetingCommand(
         Instant endTime,
         Long divisionId,
         Long organizerId,
-        List<Long> participantUserIds) {
+        List<Long> participantUserIds,
+        List<Long> telegramGroupIds) {
 }

--- a/src/main/java/com/example/vibe1/meeting/MeetingService.java
+++ b/src/main/java/com/example/vibe1/meeting/MeetingService.java
@@ -1,7 +1,9 @@
 package com.example.vibe1.meeting;
 
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.AccessDeniedException;
@@ -10,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.vibe1.division.Division;
 import com.example.vibe1.division.DivisionRepository;
+import com.example.vibe1.telegram.MeetingTelegramNotificationService;
 import com.example.vibe1.user.Role;
 import com.example.vibe1.user.User;
 import com.example.vibe1.user.UserRepository;
@@ -20,11 +23,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MeetingService implements MeetingSyncQueryPort, MeetingSyncStatusPort, MeetingSyncAuthorizationPort {
 
+    private static final DateTimeFormatter MESSAGE_TIME_FORMAT = DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm", Locale.of("id", "ID"));
+
     private final MeetingRepository meetingRepository;
     private final MeetingParticipantRepository participantRepository;
     private final DivisionRepository divisionRepository;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final MeetingTelegramNotificationService meetingTelegramNotificationService;
 
     @Transactional
     public Meeting create(CreateMeetingCommand command) {
@@ -66,8 +72,24 @@ public class MeetingService implements MeetingSyncQueryPort, MeetingSyncStatusPo
             addParticipant(meeting, direktur, ParticipantAddedReason.DIREKTUR_AUTO);
         }
 
+        if (!command.telegramGroupIds().isEmpty()) {
+            meetingTelegramNotificationService.recordSelection(
+                    meeting.getId(), command.telegramGroupIds(), buildTelegramMessage(meeting));
+        }
+
         eventPublisher.publishEvent(new MeetingScheduledEvent(meeting.getId()));
         return meeting;
+    }
+
+    private String buildTelegramMessage(Meeting meeting) {
+        StringBuilder message = new StringBuilder()
+                .append("Undangan Rapat: ").append(meeting.getTitle()).append('\n')
+                .append("Waktu: ").append(MESSAGE_TIME_FORMAT.format(meeting.getStartTimeLocal()))
+                .append(" - ").append(MESSAGE_TIME_FORMAT.format(meeting.getEndTimeLocal()));
+        if (meeting.getMaterialLink() != null) {
+            message.append("\nMateri: ").append(meeting.getMaterialLink());
+        }
+        return message.toString();
     }
 
     private void addParticipant(Meeting meeting, User user, ParticipantAddedReason reason) {

--- a/src/main/java/com/example/vibe1/meeting/telegram/MeetingTelegramNotificationListener.java
+++ b/src/main/java/com/example/vibe1/meeting/telegram/MeetingTelegramNotificationListener.java
@@ -1,0 +1,29 @@
+package com.example.vibe1.meeting.telegram;
+
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+import com.example.vibe1.meeting.MeetingScheduledEvent;
+import com.example.vibe1.telegram.MeetingTelegramNotificationService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Lives inside the meeting module (not telegram.*): meeting -> telegram is
+ * the allowed direction (the opposite of calendar's), so meeting is the side
+ * that reaches out. The message itself was already composed and stored by
+ * MeetingService when the meeting was created (see
+ * MeetingTelegramNotificationService#recordSelection) -- this listener's only
+ * job is to trigger sending whatever was recorded for this meeting.
+ */
+@Component
+@RequiredArgsConstructor
+class MeetingTelegramNotificationListener {
+
+    private final MeetingTelegramNotificationService meetingTelegramNotificationService;
+
+    @ApplicationModuleListener
+    void on(MeetingScheduledEvent event) {
+        meetingTelegramNotificationService.sendPendingNotifications(event.meetingId());
+    }
+}

--- a/src/main/java/com/example/vibe1/meeting/web/MeetingController.java
+++ b/src/main/java/com/example/vibe1/meeting/web/MeetingController.java
@@ -26,6 +26,9 @@ import com.example.vibe1.meeting.MeetingSyncAuthorizationPort;
 import com.example.vibe1.meeting.MeetingTimeZone;
 import com.example.vibe1.meeting.NotetakerService;
 import com.example.vibe1.meeting.NotulensiAccessService;
+import com.example.vibe1.telegram.DivisionTelegramGroupService;
+import com.example.vibe1.telegram.MeetingTelegramNotificationService;
+import com.example.vibe1.telegram.TelegramGroupService;
 import com.example.vibe1.user.Role;
 import com.example.vibe1.user.User;
 import com.example.vibe1.user.UserRepository;
@@ -52,6 +55,9 @@ public class MeetingController {
     private final MeetingRepository meetingRepository;
     private final MeetingParticipantRepository participantRepository;
     private final UserRepository userRepository;
+    private final TelegramGroupService telegramGroupService;
+    private final DivisionTelegramGroupService divisionTelegramGroupService;
+    private final MeetingTelegramNotificationService meetingTelegramNotificationService;
 
     @GetMapping
     public String list(Principal principal, Model model) {
@@ -79,7 +85,17 @@ public class MeetingController {
         if (canManageNotetakers) {
             model.addAttribute("notetakerCandidates", notetakerService.findEligibleCandidates(id));
         }
+        model.addAttribute("telegramNotifications", meetingTelegramNotificationService.findByMeetingId(id));
+        // Same rule as calendar retry -- organizer or Admin.
+        model.addAttribute("canRetryTelegram", meetingSyncAuthorizationPort.canRetrySync(viewer, id));
         return "meeting/detail";
+    }
+
+    @PostMapping("/{id}/telegram-groups/{groupId}/retry")
+    public String retryTelegramNotification(@PathVariable Long id, @PathVariable Long groupId, Principal principal) {
+        meetingSyncAuthorizationPort.assertCanRetrySync(currentUser(principal), id);
+        meetingTelegramNotificationService.retry(id, groupId);
+        return "redirect:/meetings/" + id;
     }
 
     @PostMapping("/{id}/notulensi")
@@ -116,8 +132,11 @@ public class MeetingController {
     @GetMapping("/new")
     @PreAuthorize("hasRole('KETUA_DIVISI')")
     public String newForm(Principal principal, Model model) {
-        model.addAttribute("form", new MeetingForm());
-        addCandidates(currentUser(principal), model);
+        User organizer = currentUser(principal);
+        MeetingForm form = new MeetingForm();
+        form.setTelegramGroupIds(List.copyOf(divisionTelegramGroupService.findFavoriteGroupIds(organizer.getDivision().getId())));
+        model.addAttribute("form", form);
+        addCandidates(organizer, model);
         return "meeting/form";
     }
 
@@ -135,7 +154,8 @@ public class MeetingController {
                     form.getEndTime().atZone(MeetingTimeZone.WIB).toInstant(),
                     organizer.getDivision().getId(),
                     organizer.getId(),
-                    form.getParticipantUserIds());
+                    form.getParticipantUserIds(),
+                    form.getTelegramGroupIds());
             Meeting meeting = meetingService.create(command);
             return "redirect:/meetings/" + meeting.getId();
         } catch (IllegalArgumentException | NullPointerException ex) {
@@ -152,5 +172,6 @@ public class MeetingController {
 
     private void addCandidates(User organizer, Model model) {
         model.addAttribute("candidates", userRepository.findByDivisionIdAndRole(organizer.getDivision().getId(), Role.KARYAWAN));
+        model.addAttribute("telegramGroups", telegramGroupService.findActive());
     }
 }

--- a/src/main/java/com/example/vibe1/meeting/web/MeetingForm.java
+++ b/src/main/java/com/example/vibe1/meeting/web/MeetingForm.java
@@ -23,4 +23,5 @@ public class MeetingForm {
     private LocalDateTime endTime;
 
     private List<Long> participantUserIds = List.of();
+    private List<Long> telegramGroupIds = List.of();
 }

--- a/src/main/java/com/example/vibe1/telegram/MeetingTelegramGroup.java
+++ b/src/main/java/com/example/vibe1/telegram/MeetingTelegramGroup.java
@@ -56,6 +56,16 @@ public class MeetingTelegramGroup extends AuditableEntity {
     @Column(name = "send_status", nullable = false, length = 16)
     private TelegramSendStatus sendStatus = TelegramSendStatus.PENDING;
 
+    /**
+     * Composed once (by meeting.MeetingService, which has the meeting's
+     * content) when this row is first recorded, and reused verbatim on
+     * retry -- this module never depends on meeting, so it can't re-fetch
+     * the meeting's title/time/link to recompose the message later.
+     */
+    @Lob
+    @Column(name = "message_text", columnDefinition = "LONGTEXT")
+    private String messageText;
+
     @Lob
     @Column(name = "send_error", columnDefinition = "LONGTEXT")
     private String sendError;

--- a/src/main/java/com/example/vibe1/telegram/MeetingTelegramGroupRepository.java
+++ b/src/main/java/com/example/vibe1/telegram/MeetingTelegramGroupRepository.java
@@ -1,6 +1,7 @@
 package com.example.vibe1.telegram;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +10,9 @@ public interface MeetingTelegramGroupRepository extends JpaRepository<MeetingTel
 
     @Query("select m from MeetingTelegramGroup m join fetch m.telegramGroup where m.meetingId = :meetingId")
     List<MeetingTelegramGroup> findByMeetingId(Long meetingId);
+
+    @Query("select m from MeetingTelegramGroup m join fetch m.telegramGroup where m.meetingId = :meetingId and m.telegramGroup.id = :telegramGroupId")
+    Optional<MeetingTelegramGroup> findByMeetingIdAndTelegramGroupId(Long meetingId, Long telegramGroupId);
 
     boolean existsByMeetingIdAndTelegramGroupId(Long meetingId, Long telegramGroupId);
 }

--- a/src/main/java/com/example/vibe1/telegram/MeetingTelegramNotificationService.java
+++ b/src/main/java/com/example/vibe1/telegram/MeetingTelegramNotificationService.java
@@ -1,0 +1,74 @@
+package com.example.vibe1.telegram;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Sends (and retries) meeting-invite notifications to Telegram groups.
+ * Deliberately never depends on the meeting module: the message text is
+ * composed by meeting.MeetingService (which has the meeting's content) and
+ * handed in once at {@link #recordSelection}, then reused verbatim for both
+ * the initial send and any later retry -- this module never fetches meeting
+ * data itself.
+ */
+@Service
+@RequiredArgsConstructor
+public class MeetingTelegramNotificationService {
+
+    private final MeetingTelegramGroupRepository meetingTelegramGroupRepository;
+    private final TelegramGroupRepository telegramGroupRepository;
+    private final TelegramGateway telegramGateway;
+
+    @Transactional
+    public void recordSelection(Long meetingId, List<Long> telegramGroupIds, String messageText) {
+        for (Long groupId : telegramGroupIds) {
+            if (meetingTelegramGroupRepository.existsByMeetingIdAndTelegramGroupId(meetingId, groupId)) {
+                continue;
+            }
+            TelegramGroup group = telegramGroupRepository.findById(groupId)
+                    .orElseThrow(() -> new IllegalArgumentException("Grup Telegram tidak ditemukan: " + groupId));
+            MeetingTelegramGroup row = new MeetingTelegramGroup(meetingId, group);
+            row.setMessageText(messageText);
+            meetingTelegramGroupRepository.save(row);
+        }
+    }
+
+    /** Sends every row recorded for this meeting -- called once, right after the meeting is created. */
+    @Transactional
+    public void sendPendingNotifications(Long meetingId) {
+        for (MeetingTelegramGroup row : meetingTelegramGroupRepository.findByMeetingId(meetingId)) {
+            sendOne(row);
+        }
+    }
+
+    @Transactional
+    public void retry(Long meetingId, Long telegramGroupId) {
+        MeetingTelegramGroup row = meetingTelegramGroupRepository.findByMeetingIdAndTelegramGroupId(meetingId, telegramGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("Data notifikasi Telegram tidak ditemukan"));
+        sendOne(row);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MeetingTelegramGroup> findByMeetingId(Long meetingId) {
+        return meetingTelegramGroupRepository.findByMeetingId(meetingId);
+    }
+
+    private void sendOne(MeetingTelegramGroup row) {
+        try {
+            telegramGateway.sendMessage(row.getTelegramGroup().getChatId(), row.getMessageText());
+            row.setSendStatus(TelegramSendStatus.SENT);
+            row.setSendError(null);
+            row.setSentAt(Instant.now());
+        } catch (Exception e) {
+            // One group's failure must not stop the others in the same loop, nor the Calendar listener for this event.
+            row.setSendStatus(TelegramSendStatus.FAILED);
+            row.setSendError(e.getMessage());
+        }
+        meetingTelegramGroupRepository.save(row);
+    }
+}

--- a/src/main/resources/db/changelog/011-add-meeting-telegram-group-message-text.xml
+++ b/src/main/resources/db/changelog/011-add-meeting-telegram-group-message-text.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="011-add-meeting-telegram-group-message-text" author="vibe1">
+        <comment>
+            Message text is composed once by meeting.MeetingService (the only
+            module with the meeting's content) and stored here for reuse on
+            retry -- the telegram module can never depend back on meeting to
+            recompose it.
+        </comment>
+        <addColumn tableName="meeting_telegram_group">
+            <column name="message_text" type="LONGTEXT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -15,5 +15,6 @@
     <include file="db/changelog/008-create-google-authorized-client-table.xml" relativeToChangelogFile="false"/>
     <include file="db/changelog/009-create-telegram-tables.xml" relativeToChangelogFile="false"/>
     <include file="db/changelog/010-create-telegram-bot-config-table.xml" relativeToChangelogFile="false"/>
+    <include file="db/changelog/011-add-meeting-telegram-group-message-text.xml" relativeToChangelogFile="false"/>
 
 </databaseChangeLog>

--- a/src/main/resources/templates/meeting/detail.html
+++ b/src/main/resources/templates/meeting/detail.html
@@ -37,6 +37,24 @@
             </form>
         </dd>
 
+        <dt class="col-sm-3">Notifikasi Telegram</dt>
+        <dd class="col-sm-9">
+            <ul class="list-unstyled mb-0">
+                <li th:each="n : ${telegramNotifications}">
+                    <span th:text="${n.telegramGroup.name}"></span>
+                    &mdash;
+                    <span th:text="${n.sendStatus}"></span>
+                    <span class="text-danger small" th:if="${n.sendError}" th:text="${n.sendError}"></span>
+                    <form th:if="${canRetryTelegram and n.sendStatus.name() == 'FAILED'}"
+                          method="post" class="d-inline"
+                          th:action="@{/meetings/{id}/telegram-groups/{groupId}/retry(id=${meeting.id},groupId=${n.telegramGroup.id})}">
+                        <button class="btn btn-sm btn-outline-danger" type="submit">Retry</button>
+                    </form>
+                </li>
+                <li th:if="${#lists.isEmpty(telegramNotifications)}" class="text-muted">Tidak ada grup Telegram dipilih untuk rapat ini.</li>
+            </ul>
+        </dd>
+
         <dt class="col-sm-3">Peserta</dt>
         <dd class="col-sm-9">
             <ul class="list-unstyled mb-0">

--- a/src/main/resources/templates/meeting/form.html
+++ b/src/main/resources/templates/meeting/form.html
@@ -42,6 +42,17 @@
         </div>
         <p class="text-muted small">Direktur otomatis diundang ke rapat ini.</p>
 
+        <div class="mb-3">
+            <label class="form-label">Grup Telegram Tujuan Undangan</label>
+            <div class="form-check" th:each="g : ${telegramGroups}">
+                <input class="form-check-input" type="checkbox" name="telegramGroupIds"
+                       th:id="${'telegram-group-' + g.id}" th:value="${g.id}"
+                       th:checked="${form.telegramGroupIds.contains(g.id)}"/>
+                <label class="form-check-label" th:for="${'telegram-group-' + g.id}" th:text="${g.name}"></label>
+            </div>
+            <div class="form-text" th:if="${#lists.isEmpty(telegramGroups)}">Belum ada grup Telegram aktif.</div>
+        </div>
+
         <button class="btn btn-primary" type="submit">Buat Rapat</button>
         <a class="btn btn-link" th:href="@{/meetings}">Batal</a>
     </form>

--- a/src/test/java/com/example/vibe1/meeting/MeetingServiceTest.java
+++ b/src/test/java/com/example/vibe1/meeting/MeetingServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import com.example.vibe1.division.Division;
 import com.example.vibe1.division.DivisionRepository;
+import com.example.vibe1.telegram.MeetingTelegramNotificationService;
 import com.example.vibe1.user.Role;
 import com.example.vibe1.user.User;
 import com.example.vibe1.user.UserRepository;
@@ -40,12 +41,14 @@ class MeetingServiceTest {
     UserRepository userRepository;
     @Mock
     ApplicationEventPublisher eventPublisher;
+    @Mock
+    MeetingTelegramNotificationService meetingTelegramNotificationService;
 
     MeetingService service;
 
     @Test
     void direkturIsAlwaysAddedExactlyOnceEvenIfAlsoSelected() {
-        service = new MeetingService(meetingRepository, participantRepository, divisionRepository, userRepository, eventPublisher);
+        service = new MeetingService(meetingRepository, participantRepository, divisionRepository, userRepository, eventPublisher, meetingTelegramNotificationService);
 
         Division division = new Division("Engineering");
         division.setId(1L);
@@ -80,7 +83,7 @@ class MeetingServiceTest {
         Instant start = Instant.now();
         CreateMeetingCommand command = new CreateMeetingCommand(
                 "Rapat Mingguan", null, null, start, start.plus(1, ChronoUnit.HOURS),
-                1L, 10L, List.of(20L));
+                1L, 10L, List.of(20L), List.of());
 
         service.create(command);
 
@@ -97,7 +100,7 @@ class MeetingServiceTest {
 
     @Test
     void rejectsOrganizerFromDifferentDivision() {
-        service = new MeetingService(meetingRepository, participantRepository, divisionRepository, userRepository, eventPublisher);
+        service = new MeetingService(meetingRepository, participantRepository, divisionRepository, userRepository, eventPublisher, meetingTelegramNotificationService);
 
         Division division = new Division("Engineering");
         division.setId(1L);
@@ -114,7 +117,7 @@ class MeetingServiceTest {
 
         Instant start = Instant.now();
         CreateMeetingCommand command = new CreateMeetingCommand(
-                "Rapat", null, null, start, start.plus(1, ChronoUnit.HOURS), 1L, 10L, List.of());
+                "Rapat", null, null, start, start.plus(1, ChronoUnit.HOURS), 1L, 10L, List.of(), List.of());
 
         org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> service.create(command));
         verify(eventPublisher, never()).publishEvent(any());

--- a/src/test/java/com/example/vibe1/meeting/telegram/MeetingTelegramNotificationListenerTest.java
+++ b/src/test/java/com/example/vibe1/meeting/telegram/MeetingTelegramNotificationListenerTest.java
@@ -1,0 +1,27 @@
+package com.example.vibe1.meeting.telegram;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.vibe1.meeting.MeetingScheduledEvent;
+import com.example.vibe1.telegram.MeetingTelegramNotificationService;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingTelegramNotificationListenerTest {
+
+    @Mock
+    MeetingTelegramNotificationService meetingTelegramNotificationService;
+
+    @Test
+    void triggersSendingWhateverWasRecordedForTheScheduledMeeting() {
+        MeetingTelegramNotificationListener listener = new MeetingTelegramNotificationListener(meetingTelegramNotificationService);
+
+        listener.on(new MeetingScheduledEvent(42L));
+
+        verify(meetingTelegramNotificationService).sendPendingNotifications(42L);
+    }
+}

--- a/src/test/java/com/example/vibe1/meeting/web/MeetingControllerAccessTest.java
+++ b/src/test/java/com/example/vibe1/meeting/web/MeetingControllerAccessTest.java
@@ -20,6 +20,9 @@ import com.example.vibe1.meeting.NotetakerService;
 import com.example.vibe1.meeting.NotulensiAccessService;
 import com.example.vibe1.security.GoogleOidcUserService;
 import com.example.vibe1.security.SecurityConfig;
+import com.example.vibe1.telegram.DivisionTelegramGroupService;
+import com.example.vibe1.telegram.MeetingTelegramNotificationService;
+import com.example.vibe1.telegram.TelegramGroupService;
 import com.example.vibe1.user.Role;
 import com.example.vibe1.user.User;
 import com.example.vibe1.user.UserRepository;
@@ -57,6 +60,12 @@ class MeetingControllerAccessTest {
     UserRepository userRepository;
     @MockitoBean
     GoogleOidcUserService googleOidcUserService;
+    @MockitoBean
+    TelegramGroupService telegramGroupService;
+    @MockitoBean
+    DivisionTelegramGroupService divisionTelegramGroupService;
+    @MockitoBean
+    MeetingTelegramNotificationService meetingTelegramNotificationService;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/telegram/MeetingTelegramNotificationServiceTest.java
+++ b/src/test/java/com/example/vibe1/telegram/MeetingTelegramNotificationServiceTest.java
@@ -1,0 +1,106 @@
+package com.example.vibe1.telegram;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MeetingTelegramNotificationServiceTest {
+
+    @Mock
+    MeetingTelegramGroupRepository meetingTelegramGroupRepository;
+    @Mock
+    TelegramGroupRepository telegramGroupRepository;
+    @Mock
+    TelegramGateway telegramGateway;
+
+    MeetingTelegramNotificationService service;
+
+    @Test
+    void recordSelectionSkipsGroupsAlreadyRecordedForMeeting() {
+        service = new MeetingTelegramNotificationService(meetingTelegramGroupRepository, telegramGroupRepository, telegramGateway);
+        TelegramGroup group = new TelegramGroup("Divisi Engineering", "-100123");
+        group.setId(2L);
+        when(meetingTelegramGroupRepository.existsByMeetingIdAndTelegramGroupId(1L, 1L)).thenReturn(true);
+        when(meetingTelegramGroupRepository.existsByMeetingIdAndTelegramGroupId(1L, 2L)).thenReturn(false);
+        when(telegramGroupRepository.findById(2L)).thenReturn(Optional.of(group));
+        when(meetingTelegramGroupRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.recordSelection(1L, List.of(1L, 2L), "Undangan Rapat: Rapat Mingguan");
+
+        ArgumentCaptor<MeetingTelegramGroup> captor = ArgumentCaptor.forClass(MeetingTelegramGroup.class);
+        verify(meetingTelegramGroupRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getMeetingId()).isEqualTo(1L);
+        assertThat(captor.getValue().getTelegramGroup()).isEqualTo(group);
+        assertThat(captor.getValue().getMessageText()).isEqualTo("Undangan Rapat: Rapat Mingguan");
+    }
+
+    @Test
+    void sendPendingNotificationsMarksEachRowSentOnGatewaySuccess() {
+        service = new MeetingTelegramNotificationService(meetingTelegramGroupRepository, telegramGroupRepository, telegramGateway);
+        TelegramGroup group = new TelegramGroup("Divisi Engineering", "-100123");
+        group.setId(2L);
+        MeetingTelegramGroup row = new MeetingTelegramGroup(1L, group);
+        row.setMessageText("Undangan Rapat: Rapat Mingguan");
+        when(meetingTelegramGroupRepository.findByMeetingId(1L)).thenReturn(List.of(row));
+        lenient().when(meetingTelegramGroupRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.sendPendingNotifications(1L);
+
+        verify(telegramGateway).sendMessage("-100123", "Undangan Rapat: Rapat Mingguan");
+        assertThat(row.getSendStatus()).isEqualTo(TelegramSendStatus.SENT);
+        assertThat(row.getSendError()).isNull();
+        assertThat(row.getSentAt()).isNotNull();
+    }
+
+    @Test
+    void sendPendingNotificationsMarksRowFailedOnGatewayException() {
+        service = new MeetingTelegramNotificationService(meetingTelegramGroupRepository, telegramGroupRepository, telegramGateway);
+        TelegramGroup group = new TelegramGroup("Divisi Engineering", "-100123");
+        group.setId(2L);
+        MeetingTelegramGroup row = new MeetingTelegramGroup(1L, group);
+        row.setMessageText("Undangan Rapat: Rapat Mingguan");
+        when(meetingTelegramGroupRepository.findByMeetingId(1L)).thenReturn(List.of(row));
+        lenient().when(meetingTelegramGroupRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        org.mockito.Mockito.doThrow(new TelegramSendException("chat not found"))
+                .when(telegramGateway).sendMessage(eq("-100123"), any());
+
+        service.sendPendingNotifications(1L);
+
+        assertThat(row.getSendStatus()).isEqualTo(TelegramSendStatus.FAILED);
+        assertThat(row.getSendError()).isEqualTo("chat not found");
+    }
+
+    @Test
+    void retrySendsOnlyTheRequestedMeetingGroupPair() {
+        service = new MeetingTelegramNotificationService(meetingTelegramGroupRepository, telegramGroupRepository, telegramGateway);
+        TelegramGroup group = new TelegramGroup("Divisi Engineering", "-100123");
+        group.setId(2L);
+        MeetingTelegramGroup row = new MeetingTelegramGroup(1L, group);
+        row.setMessageText("Undangan Rapat: Rapat Mingguan");
+        row.setSendStatus(TelegramSendStatus.FAILED);
+        row.setSendError("previous error");
+        when(meetingTelegramGroupRepository.findByMeetingIdAndTelegramGroupId(1L, 2L)).thenReturn(Optional.of(row));
+        lenient().when(meetingTelegramGroupRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.retry(1L, 2L);
+
+        verify(telegramGateway).sendMessage("-100123", "Undangan Rapat: Rapat Mingguan");
+        assertThat(row.getSendStatus()).isEqualTo(TelegramSendStatus.SENT);
+        verify(meetingTelegramGroupRepository, never()).findByMeetingId(any());
+    }
+}


### PR DESCRIPTION
## Summary
- Meeting-creation form gains a Telegram group picker, pre-filled with the organizer's division favorites (`DivisionTelegramGroupService.findFavoriteGroupIds`).
- On meeting creation, `MeetingService` composes the notification message once and records the selected groups via `MeetingTelegramNotificationService.recordSelection`.
- A new internal listener (`meeting.telegram.MeetingTelegramNotificationListener`) reacts to the existing `MeetingScheduledEvent` to trigger sending — placed inside the `meeting` module (not `telegram`) per the `meeting → telegram` one-way dependency direction established for issue #7.
- Meeting detail page shows per-group Telegram send status with a manual retry button, gated by the same organizer-or-Admin rule (`MeetingSyncAuthorizationPort`) already used for Calendar sync retry.
- New Liquibase changeset 011 adds `message_text` to `meeting_telegram_group`, derived via the project's Hibernate schema-export procedure and verified with `ddl-auto=validate`.

Closes #10.

## Test plan
- [x] `./gradlew build` — full suite green, including new `MeetingTelegramNotificationServiceTest`, `MeetingTelegramNotificationListenerTest`, and updated `MeetingServiceTest`/`MeetingControllerAccessTest`
- [x] `ModularityTests` passes — confirms no `telegram → meeting` cycle was introduced
- [x] Schema-export verified against changeset 011, then re-ran with `ddl-auto=validate` to confirm clean validation