### PR TITLE
Add cross-module Telegram tests: event-driven send flow, retry gate

### DIFF
--- a/src/test/java/com/example/vibe1/meeting/telegram/MeetingTelegramNotificationIntegrationTest.java
+++ b/src/test/java/com/example/vibe1/meeting/telegram/MeetingTelegramNotificationIntegrationTest.java
@@ -1,0 +1,130 @@
+package com.example.vibe1.meeting.telegram;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.modulith.test.EnableScenarios;
+import org.springframework.modulith.test.Scenario;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.example.vibe1.division.Division;
+import com.example.vibe1.division.DivisionRepository;
+import com.example.vibe1.meeting.CreateMeetingCommand;
+import com.example.vibe1.meeting.MeetingService;
+import com.example.vibe1.telegram.MeetingTelegramGroupRepository;
+import com.example.vibe1.telegram.TelegramGateway;
+import com.example.vibe1.telegram.TelegramGroup;
+import com.example.vibe1.telegram.TelegramGroupRepository;
+import com.example.vibe1.telegram.TelegramSendException;
+import com.example.vibe1.telegram.TelegramSendStatus;
+import com.example.vibe1.user.Role;
+import com.example.vibe1.user.User;
+import com.example.vibe1.user.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Proves the whole cross-module round trip actually wired up end to end:
+ * MeetingService.create() -> MeetingScheduledEvent published (durably, via
+ * Modulith's event publication registry) -> meeting.telegram's internal
+ * listener picks it up -> telegram.MeetingTelegramNotificationService calls
+ * the (mocked) TelegramGateway -> the MeetingTelegramGroup row is updated
+ * with the real send outcome. The listener runs async/after-commit (see
+ * ApplicationModuleListener), so this needs a real transactional context and
+ * Scenario's polling, not a plain synchronous assertion.
+ */
+@Testcontainers
+@SpringBootTest
+@EnableScenarios
+class MeetingTelegramNotificationIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static final MariaDBContainer<?> mariaDb = new MariaDBContainer<>("mariadb:11");
+
+    @MockitoBean
+    TelegramGateway telegramGateway;
+
+    @Autowired
+    MeetingService meetingService;
+    @Autowired
+    DivisionRepository divisionRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    TelegramGroupRepository telegramGroupRepository;
+    @Autowired
+    MeetingTelegramGroupRepository meetingTelegramGroupRepository;
+
+    Division division;
+    User ketua;
+    TelegramGroup group;
+
+    @BeforeEach
+    void seed() {
+        division = divisionRepository.save(new Division("Engineering " + System.nanoTime()));
+
+        ketua = new User();
+        ketua.setEmail("ketua-" + System.nanoTime() + "@company.local");
+        ketua.setFullName("Ketua Divisi Test");
+        ketua.setRole(Role.KETUA_DIVISI);
+        ketua.setDivision(division);
+        ketua = userRepository.save(ketua);
+
+        group = telegramGroupRepository.save(new TelegramGroup("Grup Engineering", "-100" + System.nanoTime()));
+    }
+
+    private CreateMeetingCommand command() {
+        Instant start = Instant.now();
+        return new CreateMeetingCommand(
+                "Rapat Mingguan", null, null, start, start.plus(1, ChronoUnit.HOURS),
+                division.getId(), ketua.getId(), List.of(), List.of(group.getId()));
+    }
+
+    @Test
+    void gatewaySuccessMarksRowSent(Scenario scenario) {
+        AtomicLong meetingId = new AtomicLong();
+
+        scenario.stimulate(() -> meetingId.set(meetingService.create(command()).getId()))
+                .andWaitForStateChange(() -> meetingTelegramGroupRepository.findByMeetingId(meetingId.get()),
+                        rows -> !rows.isEmpty() && rows.get(0).getSendStatus() != TelegramSendStatus.PENDING)
+                .andVerify(rows -> {
+                    assertThat(rows).hasSize(1);
+                    assertThat(rows.get(0).getSendStatus()).isEqualTo(TelegramSendStatus.SENT);
+                    assertThat(rows.get(0).getSentAt()).isNotNull();
+                });
+
+        verify(telegramGateway).sendMessage(eq(group.getChatId()), any());
+    }
+
+    @Test
+    void gatewayFailureMarksRowFailedWithErrorMessage(Scenario scenario) {
+        doThrow(new TelegramSendException("chat not found"))
+                .when(telegramGateway).sendMessage(eq(group.getChatId()), any());
+
+        AtomicLong meetingId = new AtomicLong();
+
+        scenario.stimulate(() -> meetingId.set(meetingService.create(command()).getId()))
+                .andWaitForStateChange(() -> meetingTelegramGroupRepository.findByMeetingId(meetingId.get()),
+                        rows -> !rows.isEmpty() && rows.get(0).getSendStatus() != TelegramSendStatus.PENDING)
+                .andVerify(rows -> {
+                    assertThat(rows).hasSize(1);
+                    assertThat(rows.get(0).getSendStatus()).isEqualTo(TelegramSendStatus.FAILED);
+                    assertThat(rows.get(0).getSendError()).isEqualTo("chat not found");
+                });
+    }
+}

--- a/src/test/java/com/example/vibe1/meeting/web/MeetingControllerAccessTest.java
+++ b/src/test/java/com/example/vibe1/meeting/web/MeetingControllerAccessTest.java
@@ -30,9 +30,13 @@ import com.example.vibe1.user.UserRepository;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -88,5 +92,45 @@ class MeetingControllerAccessTest {
 
         mockMvc.perform(get("/meetings/5").with(user("karyawan@company.local").roles("KARYAWAN")))
                 .andExpect(status().isForbidden());
+    }
+
+    /**
+     * The Telegram retry action reuses {@link com.example.vibe1.meeting.MeetingSyncAuthorizationPort},
+     * the same organizer-or-Admin rule as Calendar sync retry -- see {@code CalendarSyncControllerTest}
+     * for the analogous coverage on that endpoint.
+     */
+    @Test
+    void telegramRetryDeniedForNonOrganizerSurfacesAs403AndNeverRetries() throws Exception {
+        User otherKetua = new User();
+        otherKetua.setEmail("ketua-lain@company.local");
+        otherKetua.setRole(Role.KETUA_DIVISI);
+
+        when(userRepository.findByEmailIgnoreCase("ketua-lain@company.local")).thenReturn(Optional.of(otherKetua));
+        doThrow(new AccessDeniedException("Anda tidak berhak menjalankan ulang sync rapat ini"))
+                .when(meetingService).assertCanRetrySync(eq(otherKetua), eq(9L));
+
+        mockMvc.perform(post("/meetings/9/telegram-groups/3/retry")
+                        .with(user("ketua-lain@company.local").roles("KETUA_DIVISI"))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
+        verify(meetingTelegramNotificationService, never()).retry(any(), any());
+    }
+
+    @Test
+    void telegramRetryAllowedForOrganizerRedirectsAndRetries() throws Exception {
+        User organizer = new User();
+        organizer.setEmail("ketua@company.local");
+        organizer.setRole(Role.KETUA_DIVISI);
+
+        when(userRepository.findByEmailIgnoreCase("ketua@company.local")).thenReturn(Optional.of(organizer));
+
+        mockMvc.perform(post("/meetings/9/telegram-groups/3/retry")
+                        .with(user("ketua@company.local").roles("KETUA_DIVISI"))
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection());
+
+        verify(meetingService).assertCanRetrySync(organizer, 9L);
+        verify(meetingTelegramNotificationService).retry(9L, 3L);
     }
 }


### PR DESCRIPTION
## Summary
- Added `MeetingTelegramNotificationIntegrationTest`: a full-context, Testcontainers-backed test that exercises the real cross-module path end to end -- `MeetingService.create()` publishes `MeetingScheduledEvent` (durably, via Modulith's event publication registry), `meeting.telegram`'s internal listener picks it up asynchronously, and the (mocked) `TelegramGateway` result is reflected on the `MeetingTelegramGroup` row as `SENT` or `FAILED`. Uses Modulith's `@EnableScenarios`/`Scenario` API to await the async `@ApplicationModuleListener` instead of asserting synchronously.
- Added coverage in `MeetingControllerAccessTest` for the Telegram retry endpoint's authorization gate: a non-organizer gets 403 and the retry never runs; the organizer succeeds and triggers `MeetingTelegramNotificationService.retry`. Mirrors `CalendarSyncControllerTest`'s coverage of the analogous Calendar retry endpoint, since both reuse `MeetingSyncAuthorizationPort`.
- `TelegramGroupAdminController`'s non-Admin-gets-403 case was already covered by `TelegramGroupAdminControllerTest` from issue #9 -- no gap there.
- Re-ran `ModularityTests`: still green, confirming no `telegram -> meeting` cycle was introduced by any of the Telegram work (#7-#10).

Closes #11.

## Test plan
- [x] `./gradlew build` -- full suite green
- [x] `ModularityTests` passes