### PR TITLE
Use the gradient hero on the sidebar

### DIFF
--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -35,9 +35,10 @@
     --color-danger-soft: #FFF1F2;
     --color-danger-border: #FFE4E6;
 
-    /* JAGR Board's login hero gradient, used only for auth-style hero
-     * panels -- kept off the persistent sidebar so nav text contrast stays
-     * constant rather than riding a moving gradient. */
+    /* JAGR Board's login hero gradient -- also used on the sidebar so the
+     * app's persistent chrome carries the same brand identity as the login
+     * hero. White nav text keeps solid contrast across the whole gradient
+     * (#6A11CB..#2575FC are both dark/saturated enough). */
     --gradient-hero: linear-gradient(135deg, #6A11CB 0%, #2575FC 100%);
 
     --sidebar-width: 240px;
@@ -68,7 +69,7 @@ h1, h2, h3, h4, h5, h6 {
     left: 0;
     bottom: 0;
     width: var(--sidebar-width);
-    background: var(--color-slate-800);
+    background: var(--gradient-hero);
     display: flex;
     flex-direction: column;
     padding: 1.5rem 1rem;


### PR DESCRIPTION
## Summary
- `.app-sidebar` background changed from solid `--color-slate-800` to `--gradient-hero` (the same purple-to-blue gradient used on the login page).
- The JAGR Board reskin (PR #19) had kept the sidebar solid deliberately, since the reference site's post-login chrome isn't inspectable without an account and a moving gradient behind nav text seemed like a contrast risk. Verified white nav text and the cyan active-state highlight both stay legible across the full gradient range.

## Test plan
- [x] `./gradlew build` -- full suite green
- [x] Verified locally with a screenshot (dev server on an alternate port, since a container from `runlocal.sh` was already occupying 8080 -- left that instance untouched) -- computed `background-image` on `.app-sidebar` confirms the gradient applies, text/active states read clearly against it.