### PR TITLE
Add Keycloak connection config: entity, encryption, admin settings UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,8 @@ GOOGLE_TOKEN_ENCRYPTION_KEY=
 # The bot token itself is NOT an env var: Admin sets it via the app UI (issue #9),
 # encrypted at rest with this key.
 TELEGRAM_TOKEN_ENCRYPTION_KEY=
+
+# openssl rand -base64 32 -- separate key from the two above. The Keycloak
+# client secret itself is NOT an env var: Admin sets it via the app UI
+# (issue #25), encrypted at rest with this key.
+KEYCLOAK_TOKEN_ENCRYPTION_KEY=

--- a/src/main/java/com/example/vibe1/security/KeycloakConfig.java
+++ b/src/main/java/com/example/vibe1/security/KeycloakConfig.java
@@ -1,0 +1,54 @@
+package com.example.vibe1.security;
+
+import com.example.vibe1.common.AuditableEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Single-row config for the app's one Keycloak SSO connection, mirroring
+ * {@code telegram.TelegramBotConfig}'s shape. Admin sets/replaces it via a
+ * form (see issue #25) -- the client secret is never displayed back once
+ * saved.
+ *
+ * <p>{@code serverUrl} and {@code realm} are stored separately (not as one
+ * pre-combined issuer URI) so the OIDC issuer path (typically
+ * {@code {serverUrl}/realms/{realm}}) can be derived when building the
+ * {@code ClientRegistration} (see issue #26), rather than risking the two
+ * pieces drifting out of sync if stored redundantly.
+ */
+@Entity
+@Table(name = "keycloak_config")
+@Getter
+@Setter
+@NoArgsConstructor
+public class KeycloakConfig extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "server_url", nullable = false)
+    private String serverUrl;
+
+    @Column(nullable = false)
+    private String realm;
+
+    @Column(name = "client_id", nullable = false)
+    private String clientId;
+
+    @Lob
+    @Convert(converter = KeycloakTokenCryptoConverter.class)
+    @Column(name = "client_secret_enc", nullable = false, columnDefinition = "LONGTEXT")
+    private String clientSecretEnc;
+}

--- a/src/main/java/com/example/vibe1/security/KeycloakConfigRepository.java
+++ b/src/main/java/com/example/vibe1/security/KeycloakConfigRepository.java
@@ -1,0 +1,10 @@
+package com.example.vibe1.security;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface KeycloakConfigRepository extends JpaRepository<KeycloakConfig, Long> {
+
+    Optional<KeycloakConfig> findFirstByOrderByIdAsc();
+}

--- a/src/main/java/com/example/vibe1/security/KeycloakConfigService.java
+++ b/src/main/java/com/example/vibe1/security/KeycloakConfigService.java
@@ -1,0 +1,53 @@
+package com.example.vibe1.security;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Keeps exactly one {@link KeycloakConfig} row -- reads/replaces it, never
+ * inserts a second one. The Admin form (issue #25) calls {@link #save} to
+ * set/update the connection details; issue #26's dynamic
+ * {@code ClientRegistrationRepository} calls {@link #currentConfig} to build
+ * the {@code keycloak} registration and must invalidate its cache whenever
+ * {@link #save} runs.
+ */
+@Service
+@RequiredArgsConstructor
+public class KeycloakConfigService {
+
+    private final KeycloakConfigRepository repository;
+
+    @Transactional(readOnly = true)
+    public Optional<KeycloakConfig> currentConfig() {
+        return repository.findFirstByOrderByIdAsc();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isConfigured() {
+        return repository.findFirstByOrderByIdAsc().isPresent();
+    }
+
+    /**
+     * {@code clientSecret} blank means "keep the existing secret unchanged" --
+     * same convention as {@code UserForm.password} / {@code TelegramSettingsForm.token}.
+     * Required on first save, since the column itself is non-nullable.
+     */
+    @Transactional
+    public void save(String serverUrl, String realm, String clientId, String clientSecret) {
+        Optional<KeycloakConfig> existing = repository.findFirstByOrderByIdAsc();
+        KeycloakConfig config = existing.orElseGet(KeycloakConfig::new);
+        config.setServerUrl(serverUrl);
+        config.setRealm(realm);
+        config.setClientId(clientId);
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            config.setClientSecretEnc(clientSecret);
+        } else if (existing.isEmpty()) {
+            throw new IllegalArgumentException("Client secret wajib diisi saat pertama kali mengatur konfigurasi Keycloak");
+        }
+        repository.save(config);
+    }
+}

--- a/src/main/java/com/example/vibe1/security/KeycloakTokenCryptoConverter.java
+++ b/src/main/java/com/example/vibe1/security/KeycloakTokenCryptoConverter.java
@@ -1,0 +1,18 @@
+package com.example.vibe1.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.example.vibe1.common.AesGcmStringConverter;
+
+import jakarta.persistence.Converter;
+
+/** Own encryption key, separate from calendar.TokenCryptoConverter's and telegram.TelegramTokenCryptoConverter's, so the secret categories don't share a key. */
+@Component
+@Converter
+public class KeycloakTokenCryptoConverter extends AesGcmStringConverter {
+
+    public KeycloakTokenCryptoConverter(@Value("${keycloak.token-encryption-key}") String base64Key) {
+        super(base64Key);
+    }
+}

--- a/src/main/java/com/example/vibe1/security/web/KeycloakSettingsController.java
+++ b/src/main/java/com/example/vibe1/security/web/KeycloakSettingsController.java
@@ -1,0 +1,49 @@
+package com.example.vibe1.security.web;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.example.vibe1.security.KeycloakConfigService;
+
+import lombok.RequiredArgsConstructor;
+
+/** The client secret is never redisplayed once saved -- only whether one is currently set. */
+@Controller
+@RequestMapping("/admin/keycloak/settings")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+public class KeycloakSettingsController {
+
+    private final KeycloakConfigService keycloakConfigService;
+
+    @GetMapping
+    public String edit(Model model) {
+        KeycloakSettingsForm form = new KeycloakSettingsForm();
+        keycloakConfigService.currentConfig().ifPresent(config -> {
+            form.setServerUrl(config.getServerUrl());
+            form.setRealm(config.getRealm());
+            form.setClientId(config.getClientId());
+        });
+        model.addAttribute("form", form);
+        model.addAttribute("configured", keycloakConfigService.isConfigured());
+        return "admin/keycloak-settings";
+    }
+
+    @PostMapping
+    public String update(@ModelAttribute("form") KeycloakSettingsForm form, BindingResult bindingResult, Model model) {
+        try {
+            keycloakConfigService.save(form.getServerUrl(), form.getRealm(), form.getClientId(), form.getClientSecret());
+            return "redirect:/admin/keycloak/settings";
+        } catch (IllegalArgumentException ex) {
+            bindingResult.reject("error", ex.getMessage());
+            model.addAttribute("configured", keycloakConfigService.isConfigured());
+            return "admin/keycloak-settings";
+        }
+    }
+}

--- a/src/main/java/com/example/vibe1/security/web/KeycloakSettingsForm.java
+++ b/src/main/java/com/example/vibe1/security/web/KeycloakSettingsForm.java
@@ -1,0 +1,16 @@
+package com.example.vibe1.security.web;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KeycloakSettingsForm {
+
+    private String serverUrl;
+    private String realm;
+    private String clientId;
+
+    /** Blank means "keep the existing secret unchanged" -- same convention as UserForm.password. */
+    private String clientSecret;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,3 +34,8 @@ google.token-encryption-key=${GOOGLE_TOKEN_ENCRYPTION_KEY:zewUwGu3cxKW1og8D1n5Np
 # and Google's OAuth tokens are different secret categories and shouldn't
 # share one key (see common.AesGcmStringConverter).
 telegram.token-encryption-key=${TELEGRAM_TOKEN_ENCRYPTION_KEY:/Pdq/AjglTn5wmdsYAGDm6iCWWlTzp3/N7tn5Xpco9M=}
+
+# Separate key from the two above -- Keycloak's client secret is yet another
+# secret category and shouldn't share a key with Google/Telegram (see
+# common.AesGcmStringConverter).
+keycloak.token-encryption-key=${KEYCLOAK_TOKEN_ENCRYPTION_KEY:VDTRHCYHEJFLq25VXqGlJOswRo7WM7aIRldnAD0Qr9A=}

--- a/src/main/resources/db/changelog/012-create-keycloak-config-table.xml
+++ b/src/main/resources/db/changelog/012-create-keycloak-config-table.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="012-create-keycloak-config-table" author="vibe1">
+        <comment>
+            Single-row config for the app's one Keycloak SSO connection, client
+            secret encrypted at rest (see common.AesGcmStringConverter /
+            security.KeycloakTokenCryptoConverter). No seed row here -- the app
+            has no Keycloak login option until Admin configures one via the UI
+            (issue #25); the login page must handle "not configured yet" itself.
+        </comment>
+        <createTable tableName="keycloak_config">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="server_url" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="realm" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="client_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="client_secret_enc" type="LONGTEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -16,5 +16,6 @@
     <include file="db/changelog/009-create-telegram-tables.xml" relativeToChangelogFile="false"/>
     <include file="db/changelog/010-create-telegram-bot-config-table.xml" relativeToChangelogFile="false"/>
     <include file="db/changelog/011-add-meeting-telegram-group-message-text.xml" relativeToChangelogFile="false"/>
+    <include file="db/changelog/012-create-keycloak-config-table.xml" relativeToChangelogFile="false"/>
 
 </databaseChangeLog>

--- a/src/main/resources/templates/admin/keycloak-settings.html
+++ b/src/main/resources/templates/admin/keycloak-settings.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/layout :: head('Konfigurasi Keycloak')}"></head>
+<body>
+<nav th:replace="~{fragments/layout :: nav}"></nav>
+<main class="container" style="max-width: 500px;">
+    <h1 class="h4 mb-3">Konfigurasi Koneksi Keycloak</h1>
+
+    <p>
+        Status: <span class="status-chip status-chip--sent" th:if="${configured}">Sudah dikonfigurasi</span>
+        <span class="status-chip status-chip--pending" th:unless="${configured}">Belum dikonfigurasi</span>
+    </p>
+
+    <form method="post" th:object="${form}" th:action="@{/admin/keycloak/settings}">
+        <div class="alert alert-danger" th:if="${#fields.hasErrors('global')}" th:errors="*{global}"></div>
+
+        <div class="mb-3">
+            <label class="form-label" for="serverUrl">URL Server Keycloak</label>
+            <input class="form-control" id="serverUrl" th:field="*{serverUrl}" placeholder="https://keycloak.company.local" required="required"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="realm">Realm</label>
+            <input class="form-control" id="realm" th:field="*{realm}" required="required"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="clientId">Client ID</label>
+            <input class="form-control" id="clientId" th:field="*{clientId}" required="required"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="clientSecret">Client Secret</label>
+            <input class="form-control" id="clientSecret" type="password" th:field="*{clientSecret}" autocomplete="off"/>
+            <div class="form-text">Kosongkan jika tidak ingin mengubah secret yang sudah tersimpan. Secret tidak pernah ditampilkan ulang setelah disimpan.</div>
+        </div>
+        <button class="btn btn-primary" type="submit">Simpan</button>
+    </form>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -23,6 +23,7 @@
         <li sec:authorize="hasRole('ADMIN')"><a class="app-sidebar__link" href="/admin/divisions">Divisi</a></li>
         <li sec:authorize="hasRole('ADMIN')"><a class="app-sidebar__link" href="/admin/users">Pengguna</a></li>
         <li sec:authorize="hasRole('ADMIN')"><a class="app-sidebar__link" href="/admin/telegram-groups">Grup Telegram</a></li>
+        <li sec:authorize="hasRole('ADMIN')"><a class="app-sidebar__link" href="/admin/keycloak/settings">Konfigurasi Keycloak</a></li>
     </ul>
     <form class="app-sidebar__logout" method="post" th:action="@{/logout}">
         <button class="app-sidebar__logout-btn" type="submit">Logout</button>

--- a/src/test/java/com/example/vibe1/security/KeycloakConfigServiceTest.java
+++ b/src/test/java/com/example/vibe1/security/KeycloakConfigServiceTest.java
@@ -1,0 +1,105 @@
+package com.example.vibe1.security;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KeycloakConfigServiceTest {
+
+    @Mock
+    KeycloakConfigRepository repository;
+
+    KeycloakConfigService service;
+
+    @Test
+    void firstSaveRequiresClientSecret() {
+        service = new KeycloakConfigService(repository);
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.save("https://keycloak.local", "company", "rapat-app", ""))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void firstSaveWithSecretCreatesRow() {
+        service = new KeycloakConfigService(repository);
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.save("https://keycloak.local", "company", "rapat-app", "s3cr3t");
+
+        ArgumentCaptor<KeycloakConfig> captor = ArgumentCaptor.forClass(KeycloakConfig.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getServerUrl()).isEqualTo("https://keycloak.local");
+        assertThat(captor.getValue().getRealm()).isEqualTo("company");
+        assertThat(captor.getValue().getClientId()).isEqualTo("rapat-app");
+        assertThat(captor.getValue().getClientSecretEnc()).isEqualTo("s3cr3t");
+    }
+
+    @Test
+    void blankSecretOnUpdateKeepsExistingSecretButUpdatesOtherFields() {
+        service = new KeycloakConfigService(repository);
+        KeycloakConfig existing = new KeycloakConfig();
+        existing.setId(1L);
+        existing.setServerUrl("https://old.local");
+        existing.setRealm("old-realm");
+        existing.setClientId("old-client");
+        existing.setClientSecretEnc("existing-secret");
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.of(existing));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.save("https://new.local", "new-realm", "new-client", "");
+
+        ArgumentCaptor<KeycloakConfig> captor = ArgumentCaptor.forClass(KeycloakConfig.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getServerUrl()).isEqualTo("https://new.local");
+        assertThat(captor.getValue().getRealm()).isEqualTo("new-realm");
+        assertThat(captor.getValue().getClientId()).isEqualTo("new-client");
+        assertThat(captor.getValue().getClientSecretEnc()).isEqualTo("existing-secret");
+    }
+
+    @Test
+    void nonBlankSecretOnUpdateReplacesSecret() {
+        service = new KeycloakConfigService(repository);
+        KeycloakConfig existing = new KeycloakConfig();
+        existing.setId(1L);
+        existing.setClientSecretEnc("old-secret");
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.of(existing));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.save("https://keycloak.local", "company", "rapat-app", "new-secret");
+
+        ArgumentCaptor<KeycloakConfig> captor = ArgumentCaptor.forClass(KeycloakConfig.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getClientSecretEnc()).isEqualTo("new-secret");
+    }
+
+    @Test
+    void isConfiguredReflectsRepositoryState() {
+        service = new KeycloakConfigService(repository);
+        lenient().when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
+
+        assertThat(service.isConfigured()).isFalse();
+
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.of(new KeycloakConfig()));
+
+        assertThat(service.isConfigured()).isTrue();
+        assertThatCode(() -> service.currentConfig()).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/example/vibe1/security/web/KeycloakSettingsControllerTest.java
+++ b/src/test/java/com/example/vibe1/security/web/KeycloakSettingsControllerTest.java
@@ -1,0 +1,79 @@
+package com.example.vibe1.security.web;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.vibe1.security.GoogleOidcUserService;
+import com.example.vibe1.security.KeycloakConfig;
+import com.example.vibe1.security.KeycloakConfigService;
+import com.example.vibe1.security.SecurityConfig;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** The saved client secret must never come back out through this page's HTML. */
+@WebMvcTest(KeycloakSettingsController.class)
+@Import(SecurityConfig.class)
+class KeycloakSettingsControllerTest {
+
+    @MockitoBean
+    KeycloakConfigService keycloakConfigService;
+    @MockitoBean
+    GoogleOidcUserService googleOidcUserService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void nonAdminGets403() throws Exception {
+        mockMvc.perform(get("/admin/keycloak/settings").with(user("karyawan@company.local").roles("KARYAWAN")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void secretValueNeverAppearsInResponseBody() throws Exception {
+        KeycloakConfig config = new KeycloakConfig();
+        config.setServerUrl("https://keycloak.company.local");
+        config.setRealm("company");
+        config.setClientId("rapat-app");
+        config.setClientSecretEnc("super-secret-value");
+        when(keycloakConfigService.currentConfig()).thenReturn(Optional.of(config));
+        when(keycloakConfigService.isConfigured()).thenReturn(true);
+
+        mockMvc.perform(get("/admin/keycloak/settings").with(user("admin@company.local").roles("ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(content().string(not(containsString("super-secret-value"))))
+                .andExpect(content().string(containsString("https://keycloak.company.local")));
+    }
+
+    @Test
+    void savingWithBlankSecretOnFirstSetupShowsErrorInsteadOf500() throws Exception {
+        doThrow(new IllegalArgumentException("Client secret wajib diisi saat pertama kali mengatur konfigurasi Keycloak"))
+                .when(keycloakConfigService).save(any(), any(), any(), any());
+
+        mockMvc.perform(post("/admin/keycloak/settings")
+                        .with(user("admin@company.local").roles("ADMIN"))
+                        .with(csrf())
+                        .param("serverUrl", "https://keycloak.local")
+                        .param("realm", "company")
+                        .param("clientId", "rapat-app")
+                        .param("clientSecret", ""))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("wajib diisi")));
+    }
+}


### PR DESCRIPTION
## Summary
- `KeycloakConfig`: single-row config table (server URL, realm, client id, encrypted client secret), mirroring `telegram.TelegramBotConfig`. `server_url`/`realm` are separate fields (not one pre-combined issuer URI) so the OIDC issuer path can be derived later without the two drifting out of sync.
- `KeycloakTokenCryptoConverter`: own encryption key (`KEYCLOAK_TOKEN_ENCRYPTION_KEY`), separate from Google's and Telegram's, following the established one-key-per-secret-category pattern.
- `KeycloakConfigService`: keeps exactly one row; blank client secret on save = keep existing secret (same convention as `UserForm.password`/`TelegramSettingsForm.token`), except the very first save requires one since the column is non-nullable.
- Admin settings page at `/admin/keycloak/settings` (Admin-only), mirroring `TelegramSettingsController`: secret never rendered back once saved, status chip shows configured/not-configured.
- Liquibase changeset 012, DDL derived via the project's Hibernate schema-export procedure, verified against `ddl-auto=validate`.

This is the "configuration" half of the Keycloak SSO plan -- the login flow itself (dynamic `ClientRegistrationRepository`, auto-provisioning, hot-reload) is issue #26, which depends on this.

Closes #25.

## Test plan
- [x] `./gradlew build` -- full suite green
- [x] `ModularityTests` passes
- [x] Ran the app locally and drove it with Playwright: saved with a blank secret on first setup (rejected with a clear form error, not a 500), then with a secret (saved, status flips to "Sudah dikonfigurasi", secret never appears in the response body). No console errors.