### PR TITLE
Implement dynamic Keycloak login SSO with auto-provisioning

### DIFF
--- a/src/main/java/com/example/vibe1/security/AppOidcUserService.java
+++ b/src/main/java/com/example/vibe1/security/AppOidcUserService.java
@@ -1,0 +1,33 @@
+package com.example.vibe1.security;
+
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@code oauth2Login().userInfoEndpoint().oidcUserService(...)} only accepts
+ * one bean, shared across every OIDC registration -- this dispatches by
+ * registration id so each identity provider keeps its own account-matching
+ * rules: {@link GoogleOidcUserService} (never auto-creates) is untouched for
+ * every registration id except {@value DynamicClientRegistrationRepository#KEYCLOAK_REGISTRATION_ID},
+ * which goes to {@link KeycloakOidcUserService} (auto-provisions).
+ */
+@Component
+@RequiredArgsConstructor
+public class AppOidcUserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
+
+    private final GoogleOidcUserService googleOidcUserService;
+    private final KeycloakOidcUserService keycloakOidcUserService;
+
+    @Override
+    public OidcUser loadUser(OidcUserRequest userRequest) {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        if (DynamicClientRegistrationRepository.KEYCLOAK_REGISTRATION_ID.equals(registrationId)) {
+            return keycloakOidcUserService.loadUser(userRequest);
+        }
+        return googleOidcUserService.loadUser(userRequest);
+    }
+}

--- a/src/main/java/com/example/vibe1/security/DynamicClientRegistrationRepository.java
+++ b/src/main/java/com/example/vibe1/security/DynamicClientRegistrationRepository.java
@@ -1,0 +1,99 @@
+package com.example.vibe1.security;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientPropertiesMapper;
+import org.springframework.context.event.EventListener;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.ClientRegistrations;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Replaces Spring Boot's auto-configured {@code ClientRegistrationRepository}
+ * entirely (Boot's {@code @ConditionalOnMissingBean} backs off once this bean
+ * exists) so a {@code keycloak} registration built from database-stored
+ * {@link KeycloakConfig} can sit alongside the two statically-configured
+ * Google registrations.
+ *
+ * <p>{@code google-login}/{@code google-calendar} are served exactly as Boot
+ * would have served them -- built once at startup via
+ * {@link OAuth2ClientPropertiesMapper} (the same mapper Boot's own
+ * auto-configuration uses internally), from {@code application.properties}.
+ * Nothing about their resolution changes.
+ *
+ * <p>{@code keycloak} is built lazily from {@link KeycloakConfigService} on
+ * first use, then cached -- OIDC issuer discovery is a network call, and
+ * doing it on every login attempt would be wasteful. The cache is dropped by
+ * {@link #onKeycloakConfigSaved} (fired synchronously by
+ * {@link KeycloakConfigService#save}), so the next login attempt after an
+ * Admin edit rebuilds it -- no restart needed. A discovery failure (bad
+ * issuer URL, server unreachable) is swallowed here rather than thrown, so
+ * {@link #findByRegistrationId} just returns {@code null} as if
+ * unconfigured, instead of surfacing a raw discovery exception mid-login.
+ */
+@Component
+class DynamicClientRegistrationRepository implements ClientRegistrationRepository {
+
+    static final String KEYCLOAK_REGISTRATION_ID = "keycloak";
+
+    private final Map<String, ClientRegistration> staticRegistrations;
+    private final KeycloakConfigService keycloakConfigService;
+    private final AtomicReference<ClientRegistration> keycloakRegistration = new AtomicReference<>();
+
+    DynamicClientRegistrationRepository(OAuth2ClientProperties properties, KeycloakConfigService keycloakConfigService) {
+        this.staticRegistrations = new OAuth2ClientPropertiesMapper(properties).asClientRegistrations();
+        this.keycloakConfigService = keycloakConfigService;
+    }
+
+    @Override
+    public ClientRegistration findByRegistrationId(String registrationId) {
+        if (KEYCLOAK_REGISTRATION_ID.equals(registrationId)) {
+            return resolveKeycloakRegistration();
+        }
+        return staticRegistrations.get(registrationId);
+    }
+
+    @EventListener
+    void onKeycloakConfigSaved(KeycloakConfigSavedEvent event) {
+        keycloakRegistration.set(null);
+    }
+
+    private ClientRegistration resolveKeycloakRegistration() {
+        ClientRegistration cached = keycloakRegistration.get();
+        if (cached != null) {
+            return cached;
+        }
+        ClientRegistration built = buildKeycloakRegistration();
+        if (built != null) {
+            keycloakRegistration.compareAndSet(null, built);
+        }
+        return built;
+    }
+
+    private ClientRegistration buildKeycloakRegistration() {
+        return keycloakConfigService.currentConfig()
+                .map(this::toClientRegistration)
+                .orElse(null);
+    }
+
+    // Package-private (not private) so tests can override it to stub out the
+    // real network call OIDC discovery makes, while exercising the real
+    // caching/invalidation logic in resolveKeycloakRegistration() untouched.
+    ClientRegistration toClientRegistration(KeycloakConfig config) {
+        String issuerUri = StringUtils.trimTrailingCharacter(config.getServerUrl(), '/')
+                + "/realms/" + config.getRealm();
+        try {
+            return ClientRegistrations.fromIssuerLocation(issuerUri)
+                    .registrationId(KEYCLOAK_REGISTRATION_ID)
+                    .clientId(config.getClientId())
+                    .clientSecret(config.getClientSecretEnc())
+                    .build();
+        } catch (RuntimeException discoveryFailed) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/example/vibe1/security/KeycloakConfigSavedEvent.java
+++ b/src/main/java/com/example/vibe1/security/KeycloakConfigSavedEvent.java
@@ -1,0 +1,16 @@
+package com.example.vibe1.security;
+
+/**
+ * Published right after {@link KeycloakConfigService#save} commits, so
+ * {@link DynamicClientRegistrationRepository} can drop its cached
+ * {@code keycloak} {@code ClientRegistration} and rebuild it (lazily, on the
+ * next login attempt) from the new config -- no restart needed.
+ *
+ * <p>Plain Spring {@code ApplicationEventPublisher}, not Modulith's durable
+ * event publication registry: this never leaves the {@code security}
+ * module, needs synchronous same-thread delivery (so the cache is already
+ * cleared by the time {@code save} returns), and a missed invalidation
+ * carries no data-loss risk worth the durability machinery.
+ */
+record KeycloakConfigSavedEvent() {
+}

--- a/src/main/java/com/example/vibe1/security/KeycloakConfigService.java
+++ b/src/main/java/com/example/vibe1/security/KeycloakConfigService.java
@@ -2,6 +2,7 @@ package com.example.vibe1.security;
 
 import java.util.Optional;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,16 +11,17 @@ import lombok.RequiredArgsConstructor;
 /**
  * Keeps exactly one {@link KeycloakConfig} row -- reads/replaces it, never
  * inserts a second one. The Admin form (issue #25) calls {@link #save} to
- * set/update the connection details; issue #26's dynamic
- * {@code ClientRegistrationRepository} calls {@link #currentConfig} to build
- * the {@code keycloak} registration and must invalidate its cache whenever
- * {@link #save} runs.
+ * set/update the connection details; {@link #save} then publishes
+ * {@link KeycloakConfigSavedEvent} so {@link DynamicClientRegistrationRepository}
+ * invalidates its cached {@code keycloak} registration -- the next login
+ * attempt picks up the new config without an app restart.
  */
 @Service
 @RequiredArgsConstructor
 public class KeycloakConfigService {
 
     private final KeycloakConfigRepository repository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public Optional<KeycloakConfig> currentConfig() {
@@ -49,5 +51,6 @@ public class KeycloakConfigService {
             throw new IllegalArgumentException("Client secret wajib diisi saat pertama kali mengatur konfigurasi Keycloak");
         }
         repository.save(config);
+        eventPublisher.publishEvent(new KeycloakConfigSavedEvent());
     }
 }

--- a/src/main/java/com/example/vibe1/security/KeycloakOidcUserService.java
+++ b/src/main/java/com/example/vibe1/security/KeycloakOidcUserService.java
@@ -1,0 +1,51 @@
+package com.example.vibe1.security;
+
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.vibe1.user.Role;
+import com.example.vibe1.user.User;
+import com.example.vibe1.user.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Maps a successful Keycloak login to a local account by email -- unlike
+ * {@link GoogleOidcUserService}, this is the one login path that
+ * auto-provisions a new {@code User} (role {@code KARYAWAN}, no division)
+ * when the email isn't registered yet, since every employee already exists
+ * in the office's Keycloak realm (see PRD US-1). Admin assigns the real
+ * division/role afterward through the existing user-management page.
+ */
+@Service
+@RequiredArgsConstructor
+class KeycloakOidcUserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
+
+    private final UserRepository userRepository;
+    private final OidcUserService delegate;
+
+    @Override
+    @Transactional
+    public OidcUser loadUser(OidcUserRequest userRequest) {
+        OidcUser oidcUser = delegate.loadUser(userRequest);
+        String email = oidcUser.getEmail();
+
+        User user = userRepository.findByEmailIgnoreCase(email)
+                .orElseGet(() -> provisionNewUser(email, oidcUser));
+
+        return new UserPrincipal(user, oidcUser);
+    }
+
+    private User provisionNewUser(String email, OidcUser oidcUser) {
+        User user = new User();
+        user.setEmail(email);
+        user.setFullName(oidcUser.getFullName() != null ? oidcUser.getFullName() : email);
+        user.setRole(Role.KARYAWAN);
+        user.setEnabled(true);
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/example/vibe1/security/SecurityConfig.java
+++ b/src/main/java/com/example/vibe1/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.vibe1.security;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -11,9 +13,20 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.web.SecurityFilterChain;
 
+/**
+ * {@code @EnableConfigurationProperties(OAuth2ClientProperties.class)} is
+ * needed here because {@link DynamicClientRegistrationRepository} replaces
+ * Spring Boot's auto-configured {@code ClientRegistrationRepository} bean --
+ * and Boot only binds {@code OAuth2ClientProperties} inside the very same
+ * {@code @ConditionalOnMissingBean(ClientRegistrationRepository.class)}
+ * configuration class that builds that default repository. Once we supply
+ * our own, that whole class (properties binding included) backs off, so we
+ * re-enable the properties binding ourselves to keep injecting it.
+ */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@EnableConfigurationProperties(OAuth2ClientProperties.class)
 public class SecurityConfig {
 
     /**
@@ -32,7 +45,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, GoogleOidcUserService googleOidcUserService) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, AppOidcUserService appOidcUserService) throws Exception {
         http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/login", "/error", "/webjars/**", "/css/**").permitAll()
@@ -44,7 +57,7 @@ public class SecurityConfig {
                 .oauth2Login(oauth2 -> oauth2
                         .loginPage("/login")
                         .failureUrl("/login?error=oauth2")
-                        .userInfoEndpoint(userInfo -> userInfo.oidcUserService(googleOidcUserService))
+                        .userInfoEndpoint(userInfo -> userInfo.oidcUserService(appOidcUserService))
                         .defaultSuccessUrl("/", false))
                 // Handles the "google-calendar" registration's authorization-code
                 // callback (see its redirect-uri override in application.properties)

--- a/src/main/java/com/example/vibe1/security/web/AuthWebController.java
+++ b/src/main/java/com/example/vibe1/security/web/AuthWebController.java
@@ -1,13 +1,22 @@
 package com.example.vibe1.security.web;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import com.example.vibe1.security.KeycloakConfigService;
+
+import lombok.RequiredArgsConstructor;
+
 @Controller
+@RequiredArgsConstructor
 public class AuthWebController {
 
+    private final KeycloakConfigService keycloakConfigService;
+
     @GetMapping("/login")
-    public String login() {
+    public String login(Model model) {
+        model.addAttribute("keycloakConfigured", keycloakConfigService.isConfigured());
         return "auth/login";
     }
 

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -24,6 +24,7 @@
             </div>
 
             <a class="btn btn-outline-secondary w-100" th:href="@{/oauth2/authorization/google-login}">Login dengan Google</a>
+            <a class="btn btn-outline-secondary w-100 mt-2" th:if="${keycloakConfigured}" th:href="@{/oauth2/authorization/keycloak}">Login dengan Keycloak</a>
 
             <div class="auth-shell__divider"><span>Atau</span></div>
 

--- a/src/test/java/com/example/vibe1/calendar/web/CalendarSyncControllerTest.java
+++ b/src/test/java/com/example/vibe1/calendar/web/CalendarSyncControllerTest.java
@@ -12,7 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.vibe1.calendar.CalendarSyncService;
 import com.example.vibe1.meeting.MeetingSyncAuthorizationPort;
-import com.example.vibe1.security.GoogleOidcUserService;
+import com.example.vibe1.security.AppOidcUserService;
 import com.example.vibe1.security.SecurityConfig;
 import com.example.vibe1.user.Role;
 import com.example.vibe1.user.User;
@@ -45,7 +45,7 @@ class CalendarSyncControllerTest {
     @MockitoBean
     UserRepository userRepository;
     @MockitoBean
-    GoogleOidcUserService googleOidcUserService;
+    AppOidcUserService appOidcUserService;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/meeting/web/MeetingControllerAccessTest.java
+++ b/src/test/java/com/example/vibe1/meeting/web/MeetingControllerAccessTest.java
@@ -18,7 +18,7 @@ import com.example.vibe1.meeting.MeetingRepository;
 import com.example.vibe1.meeting.MeetingService;
 import com.example.vibe1.meeting.NotetakerService;
 import com.example.vibe1.meeting.NotulensiAccessService;
-import com.example.vibe1.security.GoogleOidcUserService;
+import com.example.vibe1.security.AppOidcUserService;
 import com.example.vibe1.security.SecurityConfig;
 import com.example.vibe1.telegram.DivisionTelegramGroupService;
 import com.example.vibe1.telegram.MeetingTelegramNotificationService;
@@ -63,7 +63,7 @@ class MeetingControllerAccessTest {
     @MockitoBean
     UserRepository userRepository;
     @MockitoBean
-    GoogleOidcUserService googleOidcUserService;
+    AppOidcUserService appOidcUserService;
     @MockitoBean
     TelegramGroupService telegramGroupService;
     @MockitoBean

--- a/src/test/java/com/example/vibe1/security/AppOidcUserServiceTest.java
+++ b/src/test/java/com/example/vibe1/security/AppOidcUserServiceTest.java
@@ -1,0 +1,58 @@
+package com.example.vibe1.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Proves the dispatcher routes by registration id -- the actual per-provider logic is tested in each service's own test. */
+@ExtendWith(MockitoExtension.class)
+class AppOidcUserServiceTest {
+
+    @Mock
+    GoogleOidcUserService googleOidcUserService;
+    @Mock
+    KeycloakOidcUserService keycloakOidcUserService;
+    @Mock
+    OidcUserRequest userRequest;
+    @Mock
+    ClientRegistration clientRegistration;
+    @Mock
+    OidcUser oidcUser;
+
+    AppOidcUserService service;
+
+    @Test
+    void routesKeycloakRegistrationToKeycloakService() {
+        service = new AppOidcUserService(googleOidcUserService, keycloakOidcUserService);
+        when(userRequest.getClientRegistration()).thenReturn(clientRegistration);
+        when(clientRegistration.getRegistrationId()).thenReturn("keycloak");
+        when(keycloakOidcUserService.loadUser(userRequest)).thenReturn(oidcUser);
+
+        service.loadUser(userRequest);
+
+        verify(keycloakOidcUserService).loadUser(userRequest);
+        verify(googleOidcUserService, never()).loadUser(any());
+    }
+
+    @Test
+    void routesEveryOtherRegistrationToGoogleService() {
+        service = new AppOidcUserService(googleOidcUserService, keycloakOidcUserService);
+        when(userRequest.getClientRegistration()).thenReturn(clientRegistration);
+        when(clientRegistration.getRegistrationId()).thenReturn("google-login");
+        when(googleOidcUserService.loadUser(userRequest)).thenReturn(oidcUser);
+
+        service.loadUser(userRequest);
+
+        verify(googleOidcUserService).loadUser(userRequest);
+        verify(keycloakOidcUserService, never()).loadUser(any());
+    }
+}

--- a/src/test/java/com/example/vibe1/security/DynamicClientRegistrationRepositoryTest.java
+++ b/src/test/java/com/example/vibe1/security/DynamicClientRegistrationRepositoryTest.java
@@ -1,0 +1,102 @@
+package com.example.vibe1.security;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DynamicClientRegistrationRepositoryTest {
+
+    @Mock
+    KeycloakConfigService keycloakConfigService;
+
+    DynamicClientRegistrationRepository repository;
+
+    @Test
+    void staticGoogleRegistrationsAreServedFromPropertiesWithoutTouchingKeycloakConfig() {
+        repository = new DynamicClientRegistrationRepository(googlePropertiesFixture(), keycloakConfigService);
+
+        ClientRegistration registration = repository.findByRegistrationId("google-login");
+
+        assertThat(registration).isNotNull();
+        assertThat(registration.getClientId()).isEqualTo("google-client-id");
+        verifyNoInteractions(keycloakConfigService);
+    }
+
+    @Test
+    void unknownRegistrationIdReturnsNull() {
+        repository = new DynamicClientRegistrationRepository(new OAuth2ClientProperties(), keycloakConfigService);
+
+        assertThat(repository.findByRegistrationId("does-not-exist")).isNull();
+    }
+
+    @Test
+    void keycloakLookupReturnsNullWhenNotConfigured() {
+        repository = new DynamicClientRegistrationRepository(new OAuth2ClientProperties(), keycloakConfigService);
+        when(keycloakConfigService.currentConfig()).thenReturn(Optional.empty());
+
+        assertThat(repository.findByRegistrationId("keycloak")).isNull();
+    }
+
+    @Test
+    void cachesSuccessfulKeycloakRegistrationUntilConfigSavedEventInvalidatesIt() {
+        KeycloakConfig config = new KeycloakConfig();
+        config.setServerUrl("https://keycloak.local");
+        config.setRealm("company");
+        config.setClientId("rapat-app");
+        config.setClientSecretEnc("secret");
+        when(keycloakConfigService.currentConfig()).thenReturn(Optional.of(config));
+
+        ClientRegistration stub = stubClientRegistration();
+        AtomicInteger buildCount = new AtomicInteger();
+        repository = new DynamicClientRegistrationRepository(new OAuth2ClientProperties(), keycloakConfigService) {
+            @Override
+            ClientRegistration toClientRegistration(KeycloakConfig cfg) {
+                buildCount.incrementAndGet();
+                return stub;
+            }
+        };
+
+        assertThat(repository.findByRegistrationId("keycloak")).isSameAs(stub);
+        assertThat(repository.findByRegistrationId("keycloak")).isSameAs(stub);
+        assertThat(buildCount.get()).isEqualTo(1);
+
+        repository.onKeycloakConfigSaved(new KeycloakConfigSavedEvent());
+        assertThat(repository.findByRegistrationId("keycloak")).isSameAs(stub);
+        assertThat(buildCount.get()).isEqualTo(2);
+    }
+
+    private static OAuth2ClientProperties googlePropertiesFixture() {
+        OAuth2ClientProperties properties = new OAuth2ClientProperties();
+        OAuth2ClientProperties.Registration googleLogin = new OAuth2ClientProperties.Registration();
+        googleLogin.setProvider("google");
+        googleLogin.setClientId("google-client-id");
+        googleLogin.setClientSecret("google-client-secret");
+        googleLogin.setScope(Set.of("openid", "email", "profile"));
+        properties.getRegistration().put("google-login", googleLogin);
+        return properties;
+    }
+
+    private static ClientRegistration stubClientRegistration() {
+        return ClientRegistration.withRegistrationId("keycloak")
+                .clientId("rapat-app")
+                .clientSecret("secret")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .authorizationUri("https://keycloak.local/authorize")
+                .tokenUri("https://keycloak.local/token")
+                .build();
+    }
+}

--- a/src/test/java/com/example/vibe1/security/KeycloakConfigServiceTest.java
+++ b/src/test/java/com/example/vibe1/security/KeycloakConfigServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -22,27 +23,32 @@ class KeycloakConfigServiceTest {
 
     @Mock
     KeycloakConfigRepository repository;
+    @Mock
+    ApplicationEventPublisher eventPublisher;
 
     KeycloakConfigService service;
 
     @Test
     void firstSaveRequiresClientSecret() {
-        service = new KeycloakConfigService(repository);
+        service = new KeycloakConfigService(repository, eventPublisher);
         when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.save("https://keycloak.local", "company", "rapat-app", ""))
                 .isInstanceOf(IllegalArgumentException.class);
 
         verify(repository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
     @Test
     void firstSaveWithSecretCreatesRow() {
-        service = new KeycloakConfigService(repository);
+        service = new KeycloakConfigService(repository, eventPublisher);
         when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
         when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         service.save("https://keycloak.local", "company", "rapat-app", "s3cr3t");
+
+        verify(eventPublisher).publishEvent(any(KeycloakConfigSavedEvent.class));
 
         ArgumentCaptor<KeycloakConfig> captor = ArgumentCaptor.forClass(KeycloakConfig.class);
         verify(repository).save(captor.capture());
@@ -54,7 +60,7 @@ class KeycloakConfigServiceTest {
 
     @Test
     void blankSecretOnUpdateKeepsExistingSecretButUpdatesOtherFields() {
-        service = new KeycloakConfigService(repository);
+        service = new KeycloakConfigService(repository, eventPublisher);
         KeycloakConfig existing = new KeycloakConfig();
         existing.setId(1L);
         existing.setServerUrl("https://old.local");
@@ -76,7 +82,7 @@ class KeycloakConfigServiceTest {
 
     @Test
     void nonBlankSecretOnUpdateReplacesSecret() {
-        service = new KeycloakConfigService(repository);
+        service = new KeycloakConfigService(repository, eventPublisher);
         KeycloakConfig existing = new KeycloakConfig();
         existing.setId(1L);
         existing.setClientSecretEnc("old-secret");
@@ -92,7 +98,7 @@ class KeycloakConfigServiceTest {
 
     @Test
     void isConfiguredReflectsRepositoryState() {
-        service = new KeycloakConfigService(repository);
+        service = new KeycloakConfigService(repository, eventPublisher);
         lenient().when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
 
         assertThat(service.isConfigured()).isFalse();

--- a/src/test/java/com/example/vibe1/security/KeycloakOidcUserServiceTest.java
+++ b/src/test/java/com/example/vibe1/security/KeycloakOidcUserServiceTest.java
@@ -1,0 +1,107 @@
+package com.example.vibe1.security;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import com.example.vibe1.user.Role;
+import com.example.vibe1.user.User;
+import com.example.vibe1.user.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class KeycloakOidcUserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    OidcUserService delegate;
+    @Mock
+    OidcUserRequest userRequest;
+
+    KeycloakOidcUserService service;
+
+    @Test
+    void autoProvisionsNewAccountForUnregisteredEmail() {
+        service = new KeycloakOidcUserService(userRepository, delegate);
+        OidcUser oidcUser = stubOidcUser("karyawan.baru@company.local", "Karyawan Baru");
+        when(delegate.loadUser(userRequest)).thenReturn(oidcUser);
+        when(userRepository.findByEmailIgnoreCase("karyawan.baru@company.local")).thenReturn(Optional.empty());
+        when(userRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        OidcUser result = service.loadUser(userRequest);
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getEmail()).isEqualTo("karyawan.baru@company.local");
+        assertThat(captor.getValue().getFullName()).isEqualTo("Karyawan Baru");
+        assertThat(captor.getValue().getRole()).isEqualTo(Role.KARYAWAN);
+        assertThat(captor.getValue().getDivision()).isNull();
+        assertThat(captor.getValue().isEnabled()).isTrue();
+
+        assertThat(result).isInstanceOf(UserPrincipal.class);
+        assertThat(((UserPrincipal) result).getRole()).isEqualTo(Role.KARYAWAN);
+    }
+
+    @Test
+    void fallsBackToEmailAsFullNameWhenNameClaimMissing() {
+        service = new KeycloakOidcUserService(userRepository, delegate);
+        DefaultOidcUser oidcUser = mock(DefaultOidcUser.class);
+        lenient().when(oidcUser.getEmail()).thenReturn("noname@company.local");
+        lenient().when(oidcUser.getAttributes()).thenReturn(Map.of("email", "noname@company.local"));
+        lenient().when(oidcUser.getFullName()).thenReturn(null);
+        when(delegate.loadUser(userRequest)).thenReturn(oidcUser);
+        when(userRepository.findByEmailIgnoreCase("noname@company.local")).thenReturn(Optional.empty());
+        when(userRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.loadUser(userRequest);
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getFullName()).isEqualTo("noname@company.local");
+    }
+
+    @Test
+    void reusesExistingAccountForKnownEmailWithoutCreatingDuplicate() {
+        service = new KeycloakOidcUserService(userRepository, delegate);
+        OidcUser oidcUser = stubOidcUser("ketua@company.local", "Ketua Existing");
+        when(delegate.loadUser(userRequest)).thenReturn(oidcUser);
+
+        User existing = new User();
+        existing.setId(42L);
+        existing.setEmail("ketua@company.local");
+        existing.setFullName("Ketua Existing");
+        existing.setRole(Role.KETUA_DIVISI);
+        existing.setEnabled(true);
+        when(userRepository.findByEmailIgnoreCase("ketua@company.local")).thenReturn(Optional.of(existing));
+
+        OidcUser result = service.loadUser(userRequest);
+
+        verify(userRepository, never()).save(any());
+        assertThat(((UserPrincipal) result).getRole()).isEqualTo(Role.KETUA_DIVISI);
+    }
+
+    private OidcUser stubOidcUser(String email, String fullName) {
+        DefaultOidcUser oidcUser = mock(DefaultOidcUser.class);
+        lenient().when(oidcUser.getEmail()).thenReturn(email);
+        lenient().when(oidcUser.getAttributes()).thenReturn(Map.of("email", email, "name", fullName));
+        lenient().when(oidcUser.getFullName()).thenReturn(fullName);
+        return oidcUser;
+    }
+}

--- a/src/test/java/com/example/vibe1/security/web/AuthWebControllerTest.java
+++ b/src/test/java/com/example/vibe1/security/web/AuthWebControllerTest.java
@@ -1,0 +1,50 @@
+package com.example.vibe1.security.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.vibe1.security.AppOidcUserService;
+import com.example.vibe1.security.KeycloakConfigService;
+import com.example.vibe1.security.SecurityConfig;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** The "Login dengan Keycloak" option must only appear once Admin has actually configured a connection. */
+@WebMvcTest(AuthWebController.class)
+@Import(SecurityConfig.class)
+class AuthWebControllerTest {
+
+    @MockitoBean
+    KeycloakConfigService keycloakConfigService;
+    @MockitoBean
+    AppOidcUserService appOidcUserService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void keycloakButtonHiddenWhenNotConfigured() throws Exception {
+        when(keycloakConfigService.isConfigured()).thenReturn(false);
+
+        mockMvc.perform(get("/login"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.not(
+                        org.hamcrest.Matchers.containsString("Login dengan Keycloak"))));
+    }
+
+    @Test
+    void keycloakButtonShownWhenConfigured() throws Exception {
+        when(keycloakConfigService.isConfigured()).thenReturn(true);
+
+        mockMvc.perform(get("/login"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("Login dengan Keycloak")));
+    }
+}

--- a/src/test/java/com/example/vibe1/security/web/KeycloakSettingsControllerTest.java
+++ b/src/test/java/com/example/vibe1/security/web/KeycloakSettingsControllerTest.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.example.vibe1.security.GoogleOidcUserService;
+import com.example.vibe1.security.AppOidcUserService;
 import com.example.vibe1.security.KeycloakConfig;
 import com.example.vibe1.security.KeycloakConfigService;
 import com.example.vibe1.security.SecurityConfig;
@@ -34,7 +34,7 @@ class KeycloakSettingsControllerTest {
     @MockitoBean
     KeycloakConfigService keycloakConfigService;
     @MockitoBean
-    GoogleOidcUserService googleOidcUserService;
+    AppOidcUserService appOidcUserService;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/telegram/web/DivisionTelegramGroupAdminControllerTest.java
+++ b/src/test/java/com/example/vibe1/telegram/web/DivisionTelegramGroupAdminControllerTest.java
@@ -8,7 +8,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.vibe1.division.DivisionRepository;
-import com.example.vibe1.security.GoogleOidcUserService;
+import com.example.vibe1.security.AppOidcUserService;
 import com.example.vibe1.security.SecurityConfig;
 import com.example.vibe1.telegram.DivisionTelegramGroupService;
 import com.example.vibe1.telegram.TelegramGroupService;
@@ -28,7 +28,7 @@ class DivisionTelegramGroupAdminControllerTest {
     @MockitoBean
     DivisionTelegramGroupService divisionTelegramGroupService;
     @MockitoBean
-    GoogleOidcUserService googleOidcUserService;
+    AppOidcUserService appOidcUserService;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/telegram/web/TelegramGroupAdminControllerTest.java
+++ b/src/test/java/com/example/vibe1/telegram/web/TelegramGroupAdminControllerTest.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.example.vibe1.security.GoogleOidcUserService;
+import com.example.vibe1.security.AppOidcUserService;
 import com.example.vibe1.security.SecurityConfig;
 import com.example.vibe1.telegram.TelegramGroupService;
 
@@ -25,7 +25,7 @@ class TelegramGroupAdminControllerTest {
     @MockitoBean
     TelegramGroupService telegramGroupService;
     @MockitoBean
-    GoogleOidcUserService googleOidcUserService;
+    AppOidcUserService appOidcUserService;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/telegram/web/TelegramSettingsControllerTest.java
+++ b/src/test/java/com/example/vibe1/telegram/web/TelegramSettingsControllerTest.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.example.vibe1.security.GoogleOidcUserService;
+import com.example.vibe1.security.AppOidcUserService;
 import com.example.vibe1.security.SecurityConfig;
 import com.example.vibe1.telegram.TelegramBotConfigService;
 
@@ -28,7 +28,7 @@ class TelegramSettingsControllerTest {
     @MockitoBean
     TelegramBotConfigService telegramBotConfigService;
     @MockitoBean
-    GoogleOidcUserService googleOidcUserService;
+    AppOidcUserService appOidcUserService;
 
     @Autowired
     MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- `DynamicClientRegistrationRepository` replaces Spring Boot's auto-configured `ClientRegistrationRepository` entirely. Serves `google-login`/`google-calendar` exactly as Boot would (via `OAuth2ClientPropertiesMapper`, the real public API for this in Boot 4.1 -- confirmed by inspecting the jar, not assumed). Serves `keycloak` by building a `ClientRegistration` from `KeycloakConfig` via OIDC issuer discovery, cached in memory, invalidated by a new `KeycloakConfigSavedEvent` so config changes take effect on the next login attempt without a restart.
- **Real wrinkle surfaced along the way**: Boot only binds `OAuth2ClientProperties` inside the same `@ConditionalOnMissingBean(ClientRegistrationRepository.class)` configuration class that builds the default repository. Supplying our own silently loses the properties bean too. Fixed by re-declaring `@EnableConfigurationProperties(OAuth2ClientProperties.class)` directly on `SecurityConfig`.
- `KeycloakOidcUserService`: the one login path that auto-provisions a new `User` (role `KARYAWAN`, no division) when the email isn't registered yet. `GoogleOidcUserService` is untouched -- still rejects unregistered emails, no auto-create, no regression.
- `AppOidcUserService`: `oauth2Login().userInfoEndpoint().oidcUserService(...)` only accepts one bean for every OIDC registration, so this dispatches by registration id to the right service. Every existing `@WebMvcTest` slice that mocked `GoogleOidcUserService` purely for `SecurityConfig` wiring now mocks this instead.
- `auth/login.html`: "Login dengan Keycloak" only renders when `KeycloakConfigService.isConfigured()`, mirroring the `needsCalendarConsent` pattern already used on the home page.

Closes #26.

## Test plan
- [x] `./gradlew build` -- full suite green (60+ tests, including new unit tests for the dispatcher, the auto-provisioning service, and the dynamic registration repository's caching/invalidation)
- [x] `ModularityTests` passes -- everything stays inside the `security` module
- [x] Verified live against a running instance:
  - `/oauth2/authorization/google-login` still redirects to `accounts.google.com` with the real client id/scopes -- **no regression**
  - Login page shows no Keycloak option before any config exists
  - Saved a Keycloak config via the admin UI (issue #25) -> button appears immediately
  - Pointed config at an unreachable host -> degrades to the same sanitized `InvalidClientRegistrationIdException`-style 500 Spring Security already produces for an unknown registration id (confirmed in logs), not a raw crash