### PR TITLE
Add Google OAuth connection config: entity, encryption, admin settings UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,9 @@ TELEGRAM_TOKEN_ENCRYPTION_KEY=
 # client secret itself is NOT an env var: Admin sets it via the app UI
 # (issue #25), encrypted at rest with this key.
 KEYCLOAK_TOKEN_ENCRYPTION_KEY=
+
+# openssl rand -base64 32 -- separate key again. Admin manages the Google
+# OAuth client id/secret via the app UI (issue #31) -- GOOGLE_OAUTH_CLIENT_ID/
+# SECRET above stay only as the bootstrap seed for existing installs (issue
+# #32); this key encrypts the DB-stored copy, distinct from GOOGLE_TOKEN_ENCRYPTION_KEY.
+GOOGLE_OAUTH_CLIENT_ENCRYPTION_KEY=

--- a/src/main/java/com/example/vibe1/security/GoogleOAuthClientCryptoConverter.java
+++ b/src/main/java/com/example/vibe1/security/GoogleOAuthClientCryptoConverter.java
@@ -1,0 +1,24 @@
+package com.example.vibe1.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.example.vibe1.common.AesGcmStringConverter;
+
+import jakarta.persistence.Converter;
+
+/**
+ * Own encryption key, separate from every other secret category in the app --
+ * notably including {@code calendar.TokenCryptoConverter}'s
+ * {@code GOOGLE_TOKEN_ENCRYPTION_KEY}, which is a *different* Google secret
+ * category (per-user OAuth access/refresh tokens, not this OAuth client's
+ * own secret). Also separate from Keycloak's and Telegram's keys.
+ */
+@Component
+@Converter
+public class GoogleOAuthClientCryptoConverter extends AesGcmStringConverter {
+
+    public GoogleOAuthClientCryptoConverter(@Value("${google.oauth-client-encryption-key}") String base64Key) {
+        super(base64Key);
+    }
+}

--- a/src/main/java/com/example/vibe1/security/GoogleOAuthConfig.java
+++ b/src/main/java/com/example/vibe1/security/GoogleOAuthConfig.java
@@ -1,0 +1,52 @@
+package com.example.vibe1.security;
+
+import com.example.vibe1.common.AuditableEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Single-row config for the app's one Google OAuth client, mirroring
+ * {@link KeycloakConfig}'s shape. Admin sets/replaces it via a form (see
+ * issue #31) -- the client secret is never displayed back once saved.
+ *
+ * <p>No issuer/realm/server-URL fields like {@code KeycloakConfig}: Google's
+ * endpoints are already static via Spring Security's built-in
+ * {@code CommonOAuth2Provider.GOOGLE}, so there's nothing to discover --
+ * just the client id/secret this app's OAuth app was issued.
+ *
+ * <p>Not to be confused with {@code calendar.GoogleAuthorizedClientService}'s
+ * stored access/refresh tokens: those are per-user tokens issued *through*
+ * this client after a successful login/consent; this row is the client
+ * itself, one per app installation, shared by both the {@code google-login}
+ * and {@code google-calendar} registrations (see issue #29/#32).
+ */
+@Entity
+@Table(name = "google_oauth_config")
+@Getter
+@Setter
+@NoArgsConstructor
+public class GoogleOAuthConfig extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "client_id", nullable = false)
+    private String clientId;
+
+    @Lob
+    @Convert(converter = GoogleOAuthClientCryptoConverter.class)
+    @Column(name = "client_secret_enc", nullable = false, columnDefinition = "LONGTEXT")
+    private String clientSecretEnc;
+}

--- a/src/main/java/com/example/vibe1/security/GoogleOAuthConfigRepository.java
+++ b/src/main/java/com/example/vibe1/security/GoogleOAuthConfigRepository.java
@@ -1,0 +1,10 @@
+package com.example.vibe1.security;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface GoogleOAuthConfigRepository extends JpaRepository<GoogleOAuthConfig, Long> {
+
+    Optional<GoogleOAuthConfig> findFirstByOrderByIdAsc();
+}

--- a/src/main/java/com/example/vibe1/security/GoogleOAuthConfigService.java
+++ b/src/main/java/com/example/vibe1/security/GoogleOAuthConfigService.java
@@ -1,0 +1,55 @@
+package com.example.vibe1.security;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Keeps exactly one {@link GoogleOAuthConfig} row -- reads/replaces it,
+ * never inserts a second one. The Admin form (issue #31) calls {@link #save}
+ * to set/update the client id/secret.
+ *
+ * <p>Nothing reads {@link #currentConfig} yet -- the {@code google-login}/
+ * {@code google-calendar} registrations still come from
+ * {@code application.properties} until issue #32 wires this service into
+ * {@code DynamicClientRegistrationRepository} (mirroring how
+ * {@code KeycloakConfigService} stayed inert until issue #26 did the same
+ * for Keycloak).
+ */
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuthConfigService {
+
+    private final GoogleOAuthConfigRepository repository;
+
+    @Transactional(readOnly = true)
+    public Optional<GoogleOAuthConfig> currentConfig() {
+        return repository.findFirstByOrderByIdAsc();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isConfigured() {
+        return repository.findFirstByOrderByIdAsc().isPresent();
+    }
+
+    /**
+     * {@code clientSecret} blank means "keep the existing secret unchanged" --
+     * same convention as {@code UserForm.password} / {@code KeycloakSettingsForm.clientSecret}.
+     * Required on first save, since the column itself is non-nullable.
+     */
+    @Transactional
+    public void save(String clientId, String clientSecret) {
+        Optional<GoogleOAuthConfig> existing = repository.findFirstByOrderByIdAsc();
+        GoogleOAuthConfig config = existing.orElseGet(GoogleOAuthConfig::new);
+        config.setClientId(clientId);
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            config.setClientSecretEnc(clientSecret);
+        } else if (existing.isEmpty()) {
+            throw new IllegalArgumentException("Client secret wajib diisi saat pertama kali mengatur konfigurasi Google OAuth");
+        }
+        repository.save(config);
+    }
+}

--- a/src/main/java/com/example/vibe1/security/web/GoogleOAuthSettingsController.java
+++ b/src/main/java/com/example/vibe1/security/web/GoogleOAuthSettingsController.java
@@ -1,0 +1,45 @@
+package com.example.vibe1.security.web;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.example.vibe1.security.GoogleOAuthConfigService;
+
+import lombok.RequiredArgsConstructor;
+
+/** The client secret is never redisplayed once saved -- only whether one is currently set. */
+@Controller
+@RequestMapping("/admin/google-oauth/settings")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+public class GoogleOAuthSettingsController {
+
+    private final GoogleOAuthConfigService googleOAuthConfigService;
+
+    @GetMapping
+    public String edit(Model model) {
+        GoogleOAuthSettingsForm form = new GoogleOAuthSettingsForm();
+        googleOAuthConfigService.currentConfig().ifPresent(config -> form.setClientId(config.getClientId()));
+        model.addAttribute("form", form);
+        model.addAttribute("configured", googleOAuthConfigService.isConfigured());
+        return "admin/google-oauth-settings";
+    }
+
+    @PostMapping
+    public String update(@ModelAttribute("form") GoogleOAuthSettingsForm form, BindingResult bindingResult, Model model) {
+        try {
+            googleOAuthConfigService.save(form.getClientId(), form.getClientSecret());
+            return "redirect:/admin/google-oauth/settings";
+        } catch (IllegalArgumentException ex) {
+            bindingResult.reject("error", ex.getMessage());
+            model.addAttribute("configured", googleOAuthConfigService.isConfigured());
+            return "admin/google-oauth-settings";
+        }
+    }
+}

--- a/src/main/java/com/example/vibe1/security/web/GoogleOAuthSettingsForm.java
+++ b/src/main/java/com/example/vibe1/security/web/GoogleOAuthSettingsForm.java
@@ -1,0 +1,14 @@
+package com.example.vibe1.security.web;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GoogleOAuthSettingsForm {
+
+    private String clientId;
+
+    /** Blank means "keep the existing secret unchanged" -- same convention as UserForm.password. */
+    private String clientSecret;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,3 +39,8 @@ telegram.token-encryption-key=${TELEGRAM_TOKEN_ENCRYPTION_KEY:/Pdq/AjglTn5wmdsYA
 # secret category and shouldn't share a key with Google/Telegram (see
 # common.AesGcmStringConverter).
 keycloak.token-encryption-key=${KEYCLOAK_TOKEN_ENCRYPTION_KEY:VDTRHCYHEJFLq25VXqGlJOswRo7WM7aIRldnAD0Qr9A=}
+
+# Separate key again -- this encrypts GoogleOAuthConfig's client secret (the
+# OAuth app's own credential, admin-managed, issue #31), NOT the same thing
+# as google.token-encryption-key above (per-user access/refresh tokens).
+google.oauth-client-encryption-key=${GOOGLE_OAUTH_CLIENT_ENCRYPTION_KEY:kOU2kV9Wzw3F3x8bqLVzBy3vkcTld2tGIiv2bf2YKGY=}

--- a/src/main/resources/db/changelog/013-create-google-oauth-config-table.xml
+++ b/src/main/resources/db/changelog/013-create-google-oauth-config-table.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="013-create-google-oauth-config-table" author="vibe1">
+        <comment>
+            Single-row config for the app's one Google OAuth client (shared by
+            the google-login and google-calendar registrations), client secret
+            encrypted at rest (see common.AesGcmStringConverter /
+            security.GoogleOAuthClientCryptoConverter). No seed row here --
+            the google-login/google-calendar registrations still come from
+            application.properties until issue #32 wires this table in.
+        </comment>
+        <createTable tableName="google_oauth_config">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="client_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="client_secret_enc" type="LONGTEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -17,5 +17,6 @@
     <include file="db/changelog/010-create-telegram-bot-config-table.xml" relativeToChangelogFile="false"/>
     <include file="db/changelog/011-add-meeting-telegram-group-message-text.xml" relativeToChangelogFile="false"/>
     <include file="db/changelog/012-create-keycloak-config-table.xml" relativeToChangelogFile="false"/>
+    <include file="db/changelog/013-create-google-oauth-config-table.xml" relativeToChangelogFile="false"/>
 
 </databaseChangeLog>

--- a/src/main/resources/templates/admin/google-oauth-settings.html
+++ b/src/main/resources/templates/admin/google-oauth-settings.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/layout :: head('Konfigurasi Google OAuth')}"></head>
+<body>
+<nav th:replace="~{fragments/layout :: nav}"></nav>
+<main class="container" style="max-width: 500px;">
+    <h1 class="h4 mb-3">Konfigurasi Koneksi Google OAuth</h1>
+
+    <p>
+        Status: <span class="status-chip status-chip--sent" th:if="${configured}">Sudah dikonfigurasi</span>
+        <span class="status-chip status-chip--pending" th:unless="${configured}">Belum dikonfigurasi</span>
+    </p>
+
+    <p class="text-muted small">Dipakai bersama oleh login Google dan izin akses Google Calendar -- satu aplikasi OAuth di Google Cloud Console.</p>
+
+    <form method="post" th:object="${form}" th:action="@{/admin/google-oauth/settings}">
+        <div class="alert alert-danger" th:if="${#fields.hasErrors('global')}" th:errors="*{global}"></div>
+
+        <div class="mb-3">
+            <label class="form-label" for="clientId">Client ID</label>
+            <input class="form-control" id="clientId" th:field="*{clientId}" required="required"/>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="clientSecret">Client Secret</label>
+            <input class="form-control" id="clientSecret" type="password" th:field="*{clientSecret}" autocomplete="off"/>
+            <div class="form-text">Kosongkan jika tidak ingin mengubah secret yang sudah tersimpan. Secret tidak pernah ditampilkan ulang setelah disimpan.</div>
+        </div>
+        <button class="btn btn-primary" type="submit">Simpan</button>
+    </form>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -24,6 +24,7 @@
         <li sec:authorize="hasRole('ADMIN')"><a class="app-sidebar__link" href="/admin/users">Pengguna</a></li>
         <li sec:authorize="hasRole('ADMIN')"><a class="app-sidebar__link" href="/admin/telegram-groups">Grup Telegram</a></li>
         <li sec:authorize="hasRole('ADMIN')"><a class="app-sidebar__link" href="/admin/keycloak/settings">Konfigurasi Keycloak</a></li>
+        <li sec:authorize="hasRole('ADMIN')"><a class="app-sidebar__link" href="/admin/google-oauth/settings">Konfigurasi Google OAuth</a></li>
     </ul>
     <form class="app-sidebar__logout" method="post" th:action="@{/logout}">
         <button class="app-sidebar__logout-btn" type="submit">Logout</button>

--- a/src/test/java/com/example/vibe1/security/GoogleOAuthConfigServiceTest.java
+++ b/src/test/java/com/example/vibe1/security/GoogleOAuthConfigServiceTest.java
@@ -1,0 +1,99 @@
+package com.example.vibe1.security;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleOAuthConfigServiceTest {
+
+    @Mock
+    GoogleOAuthConfigRepository repository;
+
+    GoogleOAuthConfigService service;
+
+    @Test
+    void firstSaveRequiresClientSecret() {
+        service = new GoogleOAuthConfigService(repository);
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.save("rapat-app", ""))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void firstSaveWithSecretCreatesRow() {
+        service = new GoogleOAuthConfigService(repository);
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.save("rapat-app", "s3cr3t");
+
+        ArgumentCaptor<GoogleOAuthConfig> captor = ArgumentCaptor.forClass(GoogleOAuthConfig.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getClientId()).isEqualTo("rapat-app");
+        assertThat(captor.getValue().getClientSecretEnc()).isEqualTo("s3cr3t");
+    }
+
+    @Test
+    void blankSecretOnUpdateKeepsExistingSecretButUpdatesClientId() {
+        service = new GoogleOAuthConfigService(repository);
+        GoogleOAuthConfig existing = new GoogleOAuthConfig();
+        existing.setId(1L);
+        existing.setClientId("old-client");
+        existing.setClientSecretEnc("existing-secret");
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.of(existing));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.save("new-client", "");
+
+        ArgumentCaptor<GoogleOAuthConfig> captor = ArgumentCaptor.forClass(GoogleOAuthConfig.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getClientId()).isEqualTo("new-client");
+        assertThat(captor.getValue().getClientSecretEnc()).isEqualTo("existing-secret");
+    }
+
+    @Test
+    void nonBlankSecretOnUpdateReplacesSecret() {
+        service = new GoogleOAuthConfigService(repository);
+        GoogleOAuthConfig existing = new GoogleOAuthConfig();
+        existing.setId(1L);
+        existing.setClientSecretEnc("old-secret");
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.of(existing));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.save("rapat-app", "new-secret");
+
+        ArgumentCaptor<GoogleOAuthConfig> captor = ArgumentCaptor.forClass(GoogleOAuthConfig.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getClientSecretEnc()).isEqualTo("new-secret");
+    }
+
+    @Test
+    void isConfiguredReflectsRepositoryState() {
+        service = new GoogleOAuthConfigService(repository);
+        lenient().when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
+
+        assertThat(service.isConfigured()).isFalse();
+
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.of(new GoogleOAuthConfig()));
+
+        assertThat(service.isConfigured()).isTrue();
+        assertThatCode(() -> service.currentConfig()).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/example/vibe1/security/web/GoogleOAuthSettingsControllerTest.java
+++ b/src/test/java/com/example/vibe1/security/web/GoogleOAuthSettingsControllerTest.java
@@ -1,0 +1,75 @@
+package com.example.vibe1.security.web;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.vibe1.security.AppOidcUserService;
+import com.example.vibe1.security.GoogleOAuthConfig;
+import com.example.vibe1.security.GoogleOAuthConfigService;
+import com.example.vibe1.security.SecurityConfig;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** The saved client secret must never come back out through this page's HTML. */
+@WebMvcTest(GoogleOAuthSettingsController.class)
+@Import(SecurityConfig.class)
+class GoogleOAuthSettingsControllerTest {
+
+    @MockitoBean
+    GoogleOAuthConfigService googleOAuthConfigService;
+    @MockitoBean
+    AppOidcUserService appOidcUserService;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void nonAdminGets403() throws Exception {
+        mockMvc.perform(get("/admin/google-oauth/settings").with(user("karyawan@company.local").roles("KARYAWAN")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void secretValueNeverAppearsInResponseBody() throws Exception {
+        GoogleOAuthConfig config = new GoogleOAuthConfig();
+        config.setClientId("rapat-app-client-id");
+        config.setClientSecretEnc("super-secret-value");
+        when(googleOAuthConfigService.currentConfig()).thenReturn(Optional.of(config));
+        when(googleOAuthConfigService.isConfigured()).thenReturn(true);
+
+        mockMvc.perform(get("/admin/google-oauth/settings").with(user("admin@company.local").roles("ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(content().string(not(containsString("super-secret-value"))))
+                .andExpect(content().string(containsString("rapat-app-client-id")));
+    }
+
+    @Test
+    void savingWithBlankSecretOnFirstSetupShowsErrorInsteadOf500() throws Exception {
+        doThrow(new IllegalArgumentException("Client secret wajib diisi saat pertama kali mengatur konfigurasi Google OAuth"))
+                .when(googleOAuthConfigService).save(any(), any());
+
+        mockMvc.perform(post("/admin/google-oauth/settings")
+                        .with(user("admin@company.local").roles("ADMIN"))
+                        .with(csrf())
+                        .param("clientId", "rapat-app-client-id")
+                        .param("clientSecret", ""))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("wajib diisi")));
+    }
+}


### PR DESCRIPTION
## Summary
- `GoogleOAuthConfig`: single-row config table (client id + encrypted client secret), mirroring `security.KeycloakConfig`. Simpler than Keycloak's shape -- no issuer/realm/server-URL fields, since Google's endpoints are already static via Spring Security's built-in `CommonOAuth2Provider.GOOGLE` (no discovery needed).
- `GoogleOAuthClientCryptoConverter`: own encryption key (`GOOGLE_OAUTH_CLIENT_ENCRYPTION_KEY`). Deliberately distinct from `calendar.TokenCryptoConverter`'s `GOOGLE_TOKEN_ENCRYPTION_KEY`, which encrypts a *different* secret category (per-user OAuth access/refresh tokens issued *through* this client, not the client's own secret) -- documented explicitly on both classes so the two never get confused.
- `GoogleOAuthConfigService`: keeps exactly one row; blank secret on save = keep existing (first save requires one). No event publishing yet -- added in #32 when something actually needs to react, mirroring how `KeycloakConfigService` stayed inert until issue #26.
- Admin settings page at `/admin/google-oauth/settings` (Admin-only), mirroring `KeycloakSettingsController`: secret never rendered back, status chip shows configured/not-configured.
- Liquibase changeset 013, DDL derived via the project's Hibernate schema-export procedure, verified against `ddl-auto=validate`.

This is the "configuration" half of the plan -- wiring it into the live `google-login`/`google-calendar` registrations is issue #32, which depends on this. Nothing existing reads `GoogleOAuthConfig` yet, so this can't affect the login path everyone uses in production today.

Closes #31.

## Test plan
- [x] `./gradlew build` -- full suite green
- [x] `ModularityTests` passes
- [x] Verified live: saved a config through the new admin page, then confirmed `/oauth2/authorization/google-login` still redirects to `accounts.google.com` using the real client id from `.env`, completely unaffected -- the new table isn't wired in yet, as designed