### PR TITLE
Wire Google OAuth into dynamic registration, drop static properties

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ DB_USERNAME=vibe1
 DB_PASSWORD=changeme
 DB_ROOT_PASSWORD=changeme-root
 
+# Read only once, at first boot, to seed GoogleOAuthConfig if that table is
+# still empty (security.GoogleOAuthConfigBootstrap) -- covers installs that
+# already had real credentials here before Admin-managed config existed.
+# After that first seed (or once Admin fills in the settings UI), these are
+# never read again; the database is the only thing google-login/google-calendar
+# actually use. Safe to leave blank on a fresh install -- Admin just fills in
+# the UI instead.
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 # openssl rand -base64 32

--- a/src/main/java/com/example/vibe1/security/DynamicClientRegistrationRepository.java
+++ b/src/main/java/com/example/vibe1/security/DynamicClientRegistrationRepository.java
@@ -1,60 +1,73 @@
 package com.example.vibe1.security;
 
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
-import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
-import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientPropertiesMapper;
 import org.springframework.context.event.EventListener;
+import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.ClientRegistrations;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 /**
  * Replaces Spring Boot's auto-configured {@code ClientRegistrationRepository}
  * entirely (Boot's {@code @ConditionalOnMissingBean} backs off once this bean
- * exists) so a {@code keycloak} registration built from database-stored
- * {@link KeycloakConfig} can sit alongside the two statically-configured
- * Google registrations.
+ * exists) so every registration this app uses -- {@code keycloak},
+ * {@code google-login}, {@code google-calendar} -- is built from
+ * database-stored config instead of {@code application.properties}.
  *
- * <p>{@code google-login}/{@code google-calendar} are served exactly as Boot
- * would have served them -- built once at startup via
- * {@link OAuth2ClientPropertiesMapper} (the same mapper Boot's own
- * auto-configuration uses internally), from {@code application.properties}.
- * Nothing about their resolution changes.
+ * <p>{@code keycloak} is built lazily from {@link KeycloakConfigService} via
+ * OIDC issuer discovery (a network call, see {@link #toClientRegistration});
+ * a discovery failure is swallowed to a {@code null} lookup rather than
+ * thrown.
  *
- * <p>{@code keycloak} is built lazily from {@link KeycloakConfigService} on
- * first use, then cached -- OIDC issuer discovery is a network call, and
- * doing it on every login attempt would be wasteful. The cache is dropped by
- * {@link #onKeycloakConfigSaved} (fired synchronously by
- * {@link KeycloakConfigService#save}), so the next login attempt after an
- * Admin edit rebuilds it -- no restart needed. A discovery failure (bad
- * issuer URL, server unreachable) is swallowed here rather than thrown, so
- * {@link #findByRegistrationId} just returns {@code null} as if
- * unconfigured, instead of surfacing a raw discovery exception mid-login.
+ * <p>{@code google-login}/{@code google-calendar} are built lazily from
+ * {@link GoogleOAuthConfigService} -- no discovery needed, since Google's
+ * endpoints are already static via Spring Security's built-in
+ * {@link CommonOAuth2Provider#GOOGLE}. Both share one {@link GoogleOAuthConfig}
+ * client id/secret (one OAuth app in Google Cloud Console, same as before
+ * this class existed) but differ in scope/grant-type/redirect-uri, matching
+ * exactly what used to be declared per-registration in
+ * {@code application.properties}.
+ *
+ * <p>Every registration is cached in memory after first build, since a
+ * database read (and, for Keycloak, a discovery call) on every single
+ * request would be wasteful. Each cache is dropped by its config's
+ * {@code *ConfigSavedEvent} (fired synchronously by the owning
+ * {@code *ConfigService.save}), so the next login/consent attempt after an
+ * Admin edit rebuilds it -- no restart needed.
  */
 @Component
 class DynamicClientRegistrationRepository implements ClientRegistrationRepository {
 
     static final String KEYCLOAK_REGISTRATION_ID = "keycloak";
+    static final String GOOGLE_LOGIN_REGISTRATION_ID = "google-login";
+    static final String GOOGLE_CALENDAR_REGISTRATION_ID = "google-calendar";
 
-    private final Map<String, ClientRegistration> staticRegistrations;
     private final KeycloakConfigService keycloakConfigService;
-    private final AtomicReference<ClientRegistration> keycloakRegistration = new AtomicReference<>();
+    private final GoogleOAuthConfigService googleOAuthConfigService;
 
-    DynamicClientRegistrationRepository(OAuth2ClientProperties properties, KeycloakConfigService keycloakConfigService) {
-        this.staticRegistrations = new OAuth2ClientPropertiesMapper(properties).asClientRegistrations();
+    private final AtomicReference<ClientRegistration> keycloakRegistration = new AtomicReference<>();
+    private final AtomicReference<ClientRegistration> googleLoginRegistration = new AtomicReference<>();
+    private final AtomicReference<ClientRegistration> googleCalendarRegistration = new AtomicReference<>();
+
+    DynamicClientRegistrationRepository(KeycloakConfigService keycloakConfigService,
+            GoogleOAuthConfigService googleOAuthConfigService) {
         this.keycloakConfigService = keycloakConfigService;
+        this.googleOAuthConfigService = googleOAuthConfigService;
     }
 
     @Override
     public ClientRegistration findByRegistrationId(String registrationId) {
-        if (KEYCLOAK_REGISTRATION_ID.equals(registrationId)) {
-            return resolveKeycloakRegistration();
-        }
-        return staticRegistrations.get(registrationId);
+        return switch (registrationId) {
+            case KEYCLOAK_REGISTRATION_ID -> resolveCached(keycloakRegistration, this::buildKeycloakRegistration);
+            case GOOGLE_LOGIN_REGISTRATION_ID -> resolveCached(googleLoginRegistration, this::buildGoogleLoginRegistration);
+            case GOOGLE_CALENDAR_REGISTRATION_ID -> resolveCached(googleCalendarRegistration, this::buildGoogleCalendarRegistration);
+            default -> null;
+        };
     }
 
     @EventListener
@@ -62,14 +75,20 @@ class DynamicClientRegistrationRepository implements ClientRegistrationRepositor
         keycloakRegistration.set(null);
     }
 
-    private ClientRegistration resolveKeycloakRegistration() {
-        ClientRegistration cached = keycloakRegistration.get();
+    @EventListener
+    void onGoogleOAuthConfigSaved(GoogleOAuthConfigSavedEvent event) {
+        googleLoginRegistration.set(null);
+        googleCalendarRegistration.set(null);
+    }
+
+    private ClientRegistration resolveCached(AtomicReference<ClientRegistration> cache, Supplier<ClientRegistration> builder) {
+        ClientRegistration cached = cache.get();
         if (cached != null) {
             return cached;
         }
-        ClientRegistration built = buildKeycloakRegistration();
+        ClientRegistration built = builder.get();
         if (built != null) {
-            keycloakRegistration.compareAndSet(null, built);
+            cache.compareAndSet(null, built);
         }
         return built;
     }
@@ -82,7 +101,7 @@ class DynamicClientRegistrationRepository implements ClientRegistrationRepositor
 
     // Package-private (not private) so tests can override it to stub out the
     // real network call OIDC discovery makes, while exercising the real
-    // caching/invalidation logic in resolveKeycloakRegistration() untouched.
+    // caching/invalidation logic in resolveCached() untouched.
     ClientRegistration toClientRegistration(KeycloakConfig config) {
         String issuerUri = StringUtils.trimTrailingCharacter(config.getServerUrl(), '/')
                 + "/realms/" + config.getRealm();
@@ -95,5 +114,33 @@ class DynamicClientRegistrationRepository implements ClientRegistrationRepositor
         } catch (RuntimeException discoveryFailed) {
             return null;
         }
+    }
+
+    private ClientRegistration buildGoogleLoginRegistration() {
+        return googleOAuthConfigService.currentConfig()
+                .map(config -> CommonOAuth2Provider.GOOGLE.getBuilder(GOOGLE_LOGIN_REGISTRATION_ID)
+                        .clientId(config.getClientId())
+                        .clientSecret(config.getClientSecretEnc())
+                        .scope("openid", "email", "profile")
+                        .build())
+                .orElse(null);
+    }
+
+    // Requested separately from google-login (incremental auth), only from
+    // organizer-capable users -- see CalendarConsentStatus. Same OAuth client
+    // as google-login, narrower scope, its own redirect-uri (must NOT be
+    // under /login/oauth2/code/** -- that path is claimed by oauth2Login()'s
+    // login filter, which would treat this callback as a login attempt
+    // instead of a plain incremental-scope grant; see SecurityConfig).
+    private ClientRegistration buildGoogleCalendarRegistration() {
+        return googleOAuthConfigService.currentConfig()
+                .map(config -> CommonOAuth2Provider.GOOGLE.getBuilder(GOOGLE_CALENDAR_REGISTRATION_ID)
+                        .clientId(config.getClientId())
+                        .clientSecret(config.getClientSecretEnc())
+                        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                        .scope("https://www.googleapis.com/auth/calendar.events")
+                        .redirectUri("{baseUrl}/connect/google-calendar")
+                        .build())
+                .orElse(null);
     }
 }

--- a/src/main/java/com/example/vibe1/security/GoogleOAuthConfigBootstrap.java
+++ b/src/main/java/com/example/vibe1/security/GoogleOAuthConfigBootstrap.java
@@ -1,0 +1,48 @@
+package com.example.vibe1.security;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * One-time migration for installs that already had real Google OAuth
+ * credentials in {@code .env} before {@link GoogleOAuthConfig} existed
+ * (issue #32) -- without this, deploying issue #31/#32 to a running install
+ * would silently break Google login and Calendar sync until an Admin
+ * remembered to fill in the new settings form.
+ *
+ * <p>Runs once per boot, but only actually does anything the very first
+ * time: if {@link GoogleOAuthConfigService#isConfigured()} is already
+ * {@code true} (seeded by a previous boot, or filled in by Admin), this is a
+ * no-op forever after -- the database becomes the sole source of truth, and
+ * {@code GOOGLE_OAUTH_CLIENT_ID}/{@code GOOGLE_OAUTH_CLIENT_SECRET} (if still
+ * present in the environment) are ignored from then on, not resynced.
+ *
+ * <p>Reads the raw environment variables directly (not through
+ * {@code application.properties}, which no longer references them) --
+ * {@link Environment} exposes OS environment variables regardless of
+ * whether any property file mentions them.
+ */
+@Component
+@RequiredArgsConstructor
+class GoogleOAuthConfigBootstrap implements ApplicationRunner {
+
+    private final GoogleOAuthConfigService googleOAuthConfigService;
+    private final Environment environment;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (googleOAuthConfigService.isConfigured()) {
+            return;
+        }
+        String clientId = environment.getProperty("GOOGLE_OAUTH_CLIENT_ID");
+        String clientSecret = environment.getProperty("GOOGLE_OAUTH_CLIENT_SECRET");
+        if (StringUtils.hasText(clientId) && StringUtils.hasText(clientSecret)) {
+            googleOAuthConfigService.save(clientId, clientSecret);
+        }
+    }
+}

--- a/src/main/java/com/example/vibe1/security/GoogleOAuthConfigSavedEvent.java
+++ b/src/main/java/com/example/vibe1/security/GoogleOAuthConfigSavedEvent.java
@@ -1,0 +1,13 @@
+package com.example.vibe1.security;
+
+/**
+ * Published right after {@link GoogleOAuthConfigService#save} commits, so
+ * {@link DynamicClientRegistrationRepository} can drop its cached
+ * {@code google-login}/{@code google-calendar} {@code ClientRegistration}s
+ * and rebuild them (lazily, on the next login/consent attempt) from the new
+ * config -- no restart needed. Mirrors {@link KeycloakConfigSavedEvent}'s
+ * rationale for using a plain Spring event rather than Modulith's durable
+ * registry.
+ */
+record GoogleOAuthConfigSavedEvent() {
+}

--- a/src/main/java/com/example/vibe1/security/GoogleOAuthConfigService.java
+++ b/src/main/java/com/example/vibe1/security/GoogleOAuthConfigService.java
@@ -2,6 +2,7 @@ package com.example.vibe1.security;
 
 import java.util.Optional;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,20 +11,19 @@ import lombok.RequiredArgsConstructor;
 /**
  * Keeps exactly one {@link GoogleOAuthConfig} row -- reads/replaces it,
  * never inserts a second one. The Admin form (issue #31) calls {@link #save}
- * to set/update the client id/secret.
- *
- * <p>Nothing reads {@link #currentConfig} yet -- the {@code google-login}/
- * {@code google-calendar} registrations still come from
- * {@code application.properties} until issue #32 wires this service into
- * {@code DynamicClientRegistrationRepository} (mirroring how
- * {@code KeycloakConfigService} stayed inert until issue #26 did the same
- * for Keycloak).
+ * to set/update the client id/secret; {@link #save} then publishes
+ * {@link GoogleOAuthConfigSavedEvent} so {@link DynamicClientRegistrationRepository}
+ * invalidates its cached {@code google-login}/{@code google-calendar}
+ * registrations -- the next login/consent attempt picks up the new config
+ * without an app restart. {@link GoogleOAuthConfigBootstrap} also calls
+ * {@link #save} once, on first startup, to seed this table from `.env`.
  */
 @Service
 @RequiredArgsConstructor
 public class GoogleOAuthConfigService {
 
     private final GoogleOAuthConfigRepository repository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public Optional<GoogleOAuthConfig> currentConfig() {
@@ -51,5 +51,6 @@ public class GoogleOAuthConfigService {
             throw new IllegalArgumentException("Client secret wajib diisi saat pertama kali mengatur konfigurasi Google OAuth");
         }
         repository.save(config);
+        eventPublisher.publishEvent(new GoogleOAuthConfigSavedEvent());
     }
 }

--- a/src/main/java/com/example/vibe1/security/SecurityConfig.java
+++ b/src/main/java/com/example/vibe1/security/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.example.vibe1.security;
 
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -13,20 +11,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.web.SecurityFilterChain;
 
-/**
- * {@code @EnableConfigurationProperties(OAuth2ClientProperties.class)} is
- * needed here because {@link DynamicClientRegistrationRepository} replaces
- * Spring Boot's auto-configured {@code ClientRegistrationRepository} bean --
- * and Boot only binds {@code OAuth2ClientProperties} inside the very same
- * {@code @ConditionalOnMissingBean(ClientRegistrationRepository.class)}
- * configuration class that builds that default repository. Once we supply
- * our own, that whole class (properties binding included) backs off, so we
- * re-enable the properties binding ourselves to keep injecting it.
- */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
-@EnableConfigurationProperties(OAuth2ClientProperties.class)
 public class SecurityConfig {
 
     /**
@@ -60,9 +47,10 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfo -> userInfo.oidcUserService(appOidcUserService))
                         .defaultSuccessUrl("/", false))
                 // Handles the "google-calendar" registration's authorization-code
-                // callback (see its redirect-uri override in application.properties)
-                // as a plain incremental-scope grant, not a login attempt --
-                // oauth2Login() alone only processes /login/oauth2/code/**.
+                // callback (see its redirect-uri override in
+                // DynamicClientRegistrationRepository) as a plain incremental-scope
+                // grant, not a login attempt -- oauth2Login() alone only processes
+                // /login/oauth2/code/**.
                 .oauth2Client(Customizer.withDefaults())
                 .logout(logout -> logout.logoutSuccessUrl("/login?logout"))
                 .exceptionHandling(exceptions -> exceptions.accessDeniedPage("/error/403"));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,28 +5,14 @@ spring.jpa.open-in-view=false
 
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
 
-# Identity-only Google login, available to every role. A second registration
-# (google-calendar) requesting Calendar write scope is added when the calendar
-# integration lands -- only organizers (Ketua Divisi/Admin) will need it.
-spring.security.oauth2.client.registration.google-login.provider=google
-spring.security.oauth2.client.registration.google-login.client-id=${GOOGLE_OAUTH_CLIENT_ID:dummy-client-id}
-spring.security.oauth2.client.registration.google-login.client-secret=${GOOGLE_OAUTH_CLIENT_SECRET:dummy-client-secret}
-spring.security.oauth2.client.registration.google-login.scope=openid,email,profile
-
-# Requested separately (incremental auth), only from organizer-capable users
-# (Ketua Divisi/Admin) -- see CalendarConsentStatus. Same OAuth client as
-# google-login, narrower scope, persisted encrypted (see calendar package).
-spring.security.oauth2.client.registration.google-calendar.provider=google
-spring.security.oauth2.client.registration.google-calendar.client-id=${GOOGLE_OAUTH_CLIENT_ID:dummy-client-id}
-spring.security.oauth2.client.registration.google-calendar.client-secret=${GOOGLE_OAUTH_CLIENT_SECRET:dummy-client-secret}
-spring.security.oauth2.client.registration.google-calendar.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.google-calendar.scope=https://www.googleapis.com/auth/calendar.events
-# Must NOT be under /login/oauth2/code/** (google-login's default) -- that
-# path is claimed by oauth2Login()'s login filter, which would treat this
-# callback as a login attempt instead of a plain incremental-scope grant.
-# NOTE: this exact URL must also be added to the OAuth client's "Authorized
-# redirect URIs" in Google Cloud Console, e.g. http://localhost:8080/connect/google-calendar
-spring.security.oauth2.client.registration.google-calendar.redirect-uri={baseUrl}/connect/google-calendar
+# google-login and google-calendar registrations are no longer declared here
+# -- both are built dynamically from GoogleOAuthConfig (admin-managed, see
+# security.DynamicClientRegistrationRepository). GOOGLE_OAUTH_CLIENT_ID/SECRET
+# still exist as env vars, but only as a one-time bootstrap seed for existing
+# installs (security.GoogleOAuthConfigBootstrap), not read here anymore.
+# NOTE: google-calendar's redirect-uri ({baseUrl}/connect/google-calendar)
+# must still be added to the OAuth client's "Authorized redirect URIs" in
+# Google Cloud Console, e.g. http://localhost:8080/connect/google-calendar.
 
 google.token-encryption-key=${GOOGLE_TOKEN_ENCRYPTION_KEY:zewUwGu3cxKW1og8D1n5Npd5ha/F5B5nK0H41GPDf8o=}
 

--- a/src/test/java/com/example/vibe1/calendar/web/CalendarSyncControllerTest.java
+++ b/src/test/java/com/example/vibe1/calendar/web/CalendarSyncControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -46,6 +47,8 @@ class CalendarSyncControllerTest {
     UserRepository userRepository;
     @MockitoBean
     AppOidcUserService appOidcUserService;
+    @MockitoBean
+    ClientRegistrationRepository clientRegistrationRepository;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/meeting/web/MeetingControllerAccessTest.java
+++ b/src/test/java/com/example/vibe1/meeting/web/MeetingControllerAccessTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -64,6 +65,8 @@ class MeetingControllerAccessTest {
     UserRepository userRepository;
     @MockitoBean
     AppOidcUserService appOidcUserService;
+    @MockitoBean
+    ClientRegistrationRepository clientRegistrationRepository;
     @MockitoBean
     TelegramGroupService telegramGroupService;
     @MockitoBean

--- a/src/test/java/com/example/vibe1/security/DynamicClientRegistrationRepositoryTest.java
+++ b/src/test/java/com/example/vibe1/security/DynamicClientRegistrationRepositoryTest.java
@@ -1,19 +1,18 @@
 package com.example.vibe1.security;
 
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.security.oauth2.client.autoconfigure.OAuth2ClientProperties;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -21,30 +20,21 @@ class DynamicClientRegistrationRepositoryTest {
 
     @Mock
     KeycloakConfigService keycloakConfigService;
+    @Mock
+    GoogleOAuthConfigService googleOAuthConfigService;
 
     DynamicClientRegistrationRepository repository;
 
     @Test
-    void staticGoogleRegistrationsAreServedFromPropertiesWithoutTouchingKeycloakConfig() {
-        repository = new DynamicClientRegistrationRepository(googlePropertiesFixture(), keycloakConfigService);
-
-        ClientRegistration registration = repository.findByRegistrationId("google-login");
-
-        assertThat(registration).isNotNull();
-        assertThat(registration.getClientId()).isEqualTo("google-client-id");
-        verifyNoInteractions(keycloakConfigService);
-    }
-
-    @Test
     void unknownRegistrationIdReturnsNull() {
-        repository = new DynamicClientRegistrationRepository(new OAuth2ClientProperties(), keycloakConfigService);
+        repository = new DynamicClientRegistrationRepository(keycloakConfigService, googleOAuthConfigService);
 
         assertThat(repository.findByRegistrationId("does-not-exist")).isNull();
     }
 
     @Test
     void keycloakLookupReturnsNullWhenNotConfigured() {
-        repository = new DynamicClientRegistrationRepository(new OAuth2ClientProperties(), keycloakConfigService);
+        repository = new DynamicClientRegistrationRepository(keycloakConfigService, googleOAuthConfigService);
         when(keycloakConfigService.currentConfig()).thenReturn(Optional.empty());
 
         assertThat(repository.findByRegistrationId("keycloak")).isNull();
@@ -59,9 +49,9 @@ class DynamicClientRegistrationRepositoryTest {
         config.setClientSecretEnc("secret");
         when(keycloakConfigService.currentConfig()).thenReturn(Optional.of(config));
 
-        ClientRegistration stub = stubClientRegistration();
+        ClientRegistration stub = stubKeycloakClientRegistration();
         AtomicInteger buildCount = new AtomicInteger();
-        repository = new DynamicClientRegistrationRepository(new OAuth2ClientProperties(), keycloakConfigService) {
+        repository = new DynamicClientRegistrationRepository(keycloakConfigService, googleOAuthConfigService) {
             @Override
             ClientRegistration toClientRegistration(KeycloakConfig cfg) {
                 buildCount.incrementAndGet();
@@ -78,18 +68,75 @@ class DynamicClientRegistrationRepositoryTest {
         assertThat(buildCount.get()).isEqualTo(2);
     }
 
-    private static OAuth2ClientProperties googlePropertiesFixture() {
-        OAuth2ClientProperties properties = new OAuth2ClientProperties();
-        OAuth2ClientProperties.Registration googleLogin = new OAuth2ClientProperties.Registration();
-        googleLogin.setProvider("google");
-        googleLogin.setClientId("google-client-id");
-        googleLogin.setClientSecret("google-client-secret");
-        googleLogin.setScope(Set.of("openid", "email", "profile"));
-        properties.getRegistration().put("google-login", googleLogin);
-        return properties;
+    @Test
+    void googleLoginLookupReturnsNullWhenNotConfigured() {
+        repository = new DynamicClientRegistrationRepository(keycloakConfigService, googleOAuthConfigService);
+        when(googleOAuthConfigService.currentConfig()).thenReturn(Optional.empty());
+
+        assertThat(repository.findByRegistrationId("google-login")).isNull();
     }
 
-    private static ClientRegistration stubClientRegistration() {
+    @Test
+    void googleCalendarLookupReturnsNullWhenNotConfigured() {
+        repository = new DynamicClientRegistrationRepository(keycloakConfigService, googleOAuthConfigService);
+        when(googleOAuthConfigService.currentConfig()).thenReturn(Optional.empty());
+
+        assertThat(repository.findByRegistrationId("google-calendar")).isNull();
+    }
+
+    @Test
+    void buildsGoogleLoginRegistrationWithIdentityScopeAndSharedCredentials() {
+        repository = new DynamicClientRegistrationRepository(keycloakConfigService, googleOAuthConfigService);
+        when(googleOAuthConfigService.currentConfig()).thenReturn(Optional.of(googleConfigFixture()));
+
+        ClientRegistration registration = repository.findByRegistrationId("google-login");
+
+        assertThat(registration).isNotNull();
+        assertThat(registration.getClientId()).isEqualTo("google-client-id");
+        assertThat(registration.getClientSecret()).isEqualTo("google-client-secret");
+        assertThat(registration.getScopes()).containsExactlyInAnyOrder("openid", "email", "profile");
+    }
+
+    @Test
+    void buildsGoogleCalendarRegistrationWithNarrowerScopeAndRedirectUriOverride() {
+        repository = new DynamicClientRegistrationRepository(keycloakConfigService, googleOAuthConfigService);
+        when(googleOAuthConfigService.currentConfig()).thenReturn(Optional.of(googleConfigFixture()));
+
+        ClientRegistration registration = repository.findByRegistrationId("google-calendar");
+
+        assertThat(registration).isNotNull();
+        assertThat(registration.getClientId()).isEqualTo("google-client-id");
+        assertThat(registration.getClientSecret()).isEqualTo("google-client-secret");
+        assertThat(registration.getScopes()).containsExactly("https://www.googleapis.com/auth/calendar.events");
+        assertThat(registration.getRedirectUri()).isEqualTo("{baseUrl}/connect/google-calendar");
+        assertThat(registration.getAuthorizationGrantType()).isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
+    }
+
+    @Test
+    void cachesGoogleRegistrationsUntilConfigSavedEventInvalidatesBoth() {
+        repository = new DynamicClientRegistrationRepository(keycloakConfigService, googleOAuthConfigService);
+        when(googleOAuthConfigService.currentConfig()).thenReturn(Optional.of(googleConfigFixture()));
+
+        repository.findByRegistrationId("google-login");
+        repository.findByRegistrationId("google-login");
+        repository.findByRegistrationId("google-calendar");
+        repository.findByRegistrationId("google-calendar");
+        verify(googleOAuthConfigService, times(2)).currentConfig();
+
+        repository.onGoogleOAuthConfigSaved(new GoogleOAuthConfigSavedEvent());
+        repository.findByRegistrationId("google-login");
+        repository.findByRegistrationId("google-calendar");
+        verify(googleOAuthConfigService, times(4)).currentConfig();
+    }
+
+    private static GoogleOAuthConfig googleConfigFixture() {
+        GoogleOAuthConfig config = new GoogleOAuthConfig();
+        config.setClientId("google-client-id");
+        config.setClientSecretEnc("google-client-secret");
+        return config;
+    }
+
+    private static ClientRegistration stubKeycloakClientRegistration() {
         return ClientRegistration.withRegistrationId("keycloak")
                 .clientId("rapat-app")
                 .clientSecret("secret")

--- a/src/test/java/com/example/vibe1/security/GoogleOAuthConfigBootstrapTest.java
+++ b/src/test/java/com/example/vibe1/security/GoogleOAuthConfigBootstrapTest.java
@@ -1,0 +1,71 @@
+package com.example.vibe1.security;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.core.env.Environment;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleOAuthConfigBootstrapTest {
+
+    @Mock
+    GoogleOAuthConfigService googleOAuthConfigService;
+    @Mock
+    Environment environment;
+
+    GoogleOAuthConfigBootstrap bootstrap;
+
+    @Test
+    void seedsConfigFromEnvWhenTableEmptyAndEnvVarsPresent() {
+        bootstrap = new GoogleOAuthConfigBootstrap(googleOAuthConfigService, environment);
+        when(googleOAuthConfigService.isConfigured()).thenReturn(false);
+        when(environment.getProperty("GOOGLE_OAUTH_CLIENT_ID")).thenReturn("env-client-id");
+        when(environment.getProperty("GOOGLE_OAUTH_CLIENT_SECRET")).thenReturn("env-client-secret");
+
+        bootstrap.run(new DefaultApplicationArguments());
+
+        verify(googleOAuthConfigService).save("env-client-id", "env-client-secret");
+    }
+
+    @Test
+    void doesNothingWhenAlreadyConfigured() {
+        bootstrap = new GoogleOAuthConfigBootstrap(googleOAuthConfigService, environment);
+        when(googleOAuthConfigService.isConfigured()).thenReturn(true);
+
+        bootstrap.run(new DefaultApplicationArguments());
+
+        verify(googleOAuthConfigService, never()).save(any(), any());
+    }
+
+    @Test
+    void doesNothingWhenEnvVarsAbsentEvenIfTableEmpty() {
+        bootstrap = new GoogleOAuthConfigBootstrap(googleOAuthConfigService, environment);
+        when(googleOAuthConfigService.isConfigured()).thenReturn(false);
+        lenient().when(environment.getProperty("GOOGLE_OAUTH_CLIENT_ID")).thenReturn(null);
+        lenient().when(environment.getProperty("GOOGLE_OAUTH_CLIENT_SECRET")).thenReturn(null);
+
+        bootstrap.run(new DefaultApplicationArguments());
+
+        verify(googleOAuthConfigService, never()).save(any(), any());
+    }
+
+    @Test
+    void doesNothingWhenOnlyOneEnvVarPresent() {
+        bootstrap = new GoogleOAuthConfigBootstrap(googleOAuthConfigService, environment);
+        when(googleOAuthConfigService.isConfigured()).thenReturn(false);
+        when(environment.getProperty("GOOGLE_OAUTH_CLIENT_ID")).thenReturn("env-client-id");
+        lenient().when(environment.getProperty("GOOGLE_OAUTH_CLIENT_SECRET")).thenReturn(null);
+
+        bootstrap.run(new DefaultApplicationArguments());
+
+        verify(googleOAuthConfigService, never()).save(any(), any());
+    }
+}

--- a/src/test/java/com/example/vibe1/security/GoogleOAuthConfigServiceTest.java
+++ b/src/test/java/com/example/vibe1/security/GoogleOAuthConfigServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -22,27 +23,32 @@ class GoogleOAuthConfigServiceTest {
 
     @Mock
     GoogleOAuthConfigRepository repository;
+    @Mock
+    ApplicationEventPublisher eventPublisher;
 
     GoogleOAuthConfigService service;
 
     @Test
     void firstSaveRequiresClientSecret() {
-        service = new GoogleOAuthConfigService(repository);
+        service = new GoogleOAuthConfigService(repository, eventPublisher);
         when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.save("rapat-app", ""))
                 .isInstanceOf(IllegalArgumentException.class);
 
         verify(repository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
     @Test
     void firstSaveWithSecretCreatesRow() {
-        service = new GoogleOAuthConfigService(repository);
+        service = new GoogleOAuthConfigService(repository, eventPublisher);
         when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
         when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         service.save("rapat-app", "s3cr3t");
+
+        verify(eventPublisher).publishEvent(any(GoogleOAuthConfigSavedEvent.class));
 
         ArgumentCaptor<GoogleOAuthConfig> captor = ArgumentCaptor.forClass(GoogleOAuthConfig.class);
         verify(repository).save(captor.capture());
@@ -52,7 +58,7 @@ class GoogleOAuthConfigServiceTest {
 
     @Test
     void blankSecretOnUpdateKeepsExistingSecretButUpdatesClientId() {
-        service = new GoogleOAuthConfigService(repository);
+        service = new GoogleOAuthConfigService(repository, eventPublisher);
         GoogleOAuthConfig existing = new GoogleOAuthConfig();
         existing.setId(1L);
         existing.setClientId("old-client");
@@ -70,7 +76,7 @@ class GoogleOAuthConfigServiceTest {
 
     @Test
     void nonBlankSecretOnUpdateReplacesSecret() {
-        service = new GoogleOAuthConfigService(repository);
+        service = new GoogleOAuthConfigService(repository, eventPublisher);
         GoogleOAuthConfig existing = new GoogleOAuthConfig();
         existing.setId(1L);
         existing.setClientSecretEnc("old-secret");
@@ -86,7 +92,7 @@ class GoogleOAuthConfigServiceTest {
 
     @Test
     void isConfiguredReflectsRepositoryState() {
-        service = new GoogleOAuthConfigService(repository);
+        service = new GoogleOAuthConfigService(repository, eventPublisher);
         lenient().when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
 
         assertThat(service.isConfigured()).isFalse();

--- a/src/test/java/com/example/vibe1/security/web/AuthWebControllerTest.java
+++ b/src/test/java/com/example/vibe1/security/web/AuthWebControllerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -25,6 +26,8 @@ class AuthWebControllerTest {
     KeycloakConfigService keycloakConfigService;
     @MockitoBean
     AppOidcUserService appOidcUserService;
+    @MockitoBean
+    ClientRegistrationRepository clientRegistrationRepository;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/security/web/GoogleOAuthSettingsControllerTest.java
+++ b/src/test/java/com/example/vibe1/security/web/GoogleOAuthSettingsControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -35,6 +36,8 @@ class GoogleOAuthSettingsControllerTest {
     GoogleOAuthConfigService googleOAuthConfigService;
     @MockitoBean
     AppOidcUserService appOidcUserService;
+    @MockitoBean
+    ClientRegistrationRepository clientRegistrationRepository;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/security/web/KeycloakSettingsControllerTest.java
+++ b/src/test/java/com/example/vibe1/security/web/KeycloakSettingsControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -35,6 +36,8 @@ class KeycloakSettingsControllerTest {
     KeycloakConfigService keycloakConfigService;
     @MockitoBean
     AppOidcUserService appOidcUserService;
+    @MockitoBean
+    ClientRegistrationRepository clientRegistrationRepository;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/telegram/web/DivisionTelegramGroupAdminControllerTest.java
+++ b/src/test/java/com/example/vibe1/telegram/web/DivisionTelegramGroupAdminControllerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -29,6 +30,8 @@ class DivisionTelegramGroupAdminControllerTest {
     DivisionTelegramGroupService divisionTelegramGroupService;
     @MockitoBean
     AppOidcUserService appOidcUserService;
+    @MockitoBean
+    ClientRegistrationRepository clientRegistrationRepository;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/telegram/web/TelegramGroupAdminControllerTest.java
+++ b/src/test/java/com/example/vibe1/telegram/web/TelegramGroupAdminControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -26,6 +27,8 @@ class TelegramGroupAdminControllerTest {
     TelegramGroupService telegramGroupService;
     @MockitoBean
     AppOidcUserService appOidcUserService;
+    @MockitoBean
+    ClientRegistrationRepository clientRegistrationRepository;
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/com/example/vibe1/telegram/web/TelegramSettingsControllerTest.java
+++ b/src/test/java/com/example/vibe1/telegram/web/TelegramSettingsControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -29,6 +30,8 @@ class TelegramSettingsControllerTest {
     TelegramBotConfigService telegramBotConfigService;
     @MockitoBean
     AppOidcUserService appOidcUserService;
+    @MockitoBean
+    ClientRegistrationRepository clientRegistrationRepository;
 
     @Autowired
     MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- `DynamicClientRegistrationRepository` no longer depends on `OAuth2ClientProperties` at all -- every registration (`keycloak`, `google-login`, `google-calendar`) is now database-driven. Google's two registrations build via Spring Security's built-in `CommonOAuth2Provider.GOOGLE` (no discovery call, unlike Keycloak) with scope/grant-type/redirect-uri matching the old static config exactly. Both share one `GoogleOAuthConfig` client id/secret, cached and invalidated via a new `GoogleOAuthConfigSavedEvent`.
- `GoogleOAuthConfigService.save()` now publishes that event -- it was deliberately inert in #31 until something needed to react.
- `GoogleOAuthConfigBootstrap`: one-time `ApplicationRunner` that seeds `GoogleOAuthConfig` from `GOOGLE_OAUTH_CLIENT_ID`/`SECRET` if the table is still empty at startup -- resolves the PRD's open bootstrap question (seed once, then the database is the sole source of truth; env vars are never read again afterward).
- `SecurityConfig`: dropped the now-unneeded `@EnableConfigurationProperties(OAuth2ClientProperties.class)`.
- Removed the static `spring.security.oauth2.client.registration.google-login.*`/`google-calendar.*` properties entirely.

## Real regression this surfaced
Every `@WebMvcTest` slice importing `SecurityConfig` was unknowingly relying on Boot's own conditional `ClientRegistrationRepository` auto-configuration as a fallback bean (since `DynamicClientRegistrationRepository`, a plain `@Component`, was never actually scanned into those minimal slices). Removing the static properties also removed the condition that fallback needed to activate. Fixed by adding an explicit `@MockitoBean ClientRegistrationRepository` to all 8 affected slices -- same pattern they already use for `AppOidcUserService`.

Closes #32.

## Test plan
- [x] `./gradlew build` -- full suite green (105 tests)
- [x] `ModularityTests` passes
- [x] Verified live end-to-end against a fresh MariaDB with real credentials in `.env`:
  - App boots, auto-seeds `google_oauth_config` from `.env` (confirmed via direct DB query -- secret genuinely encrypted, not plaintext)
  - `/oauth2/authorization/google-login` and `/oauth2/authorization/google-calendar` redirect to `accounts.google.com` with identical client id/scope/redirect-uri to the pre-migration static config -- **no regression**
  - Admin settings page shows the auto-seeded value
  - Editing it through the UI changes the very next login's redirect immediately -- hot-reload confirmed, no restart